### PR TITLE
added pending update list and Apple Silicon support

### DIFF
--- a/build-info.plist
+++ b/build-info.plist
@@ -17,6 +17,6 @@
 	<key>suppress_bundle_relocation</key>
 	<true/>
 	<key>version</key>
-	<string>4.0.3</string>
+	<string>4.1</string>
 </dict>
 </plist>

--- a/build-info.plist
+++ b/build-info.plist
@@ -17,6 +17,6 @@
 	<key>suppress_bundle_relocation</key>
 	<true/>
 	<key>version</key>
-	<string>4.0.1</string>
+	<string>4.0.2</string>
 </dict>
 </plist>

--- a/build-info.plist
+++ b/build-info.plist
@@ -17,6 +17,6 @@
 	<key>suppress_bundle_relocation</key>
 	<true/>
 	<key>version</key>
-	<string>4.0.2</string>
+	<string>4.0.3</string>
 </dict>
 </plist>

--- a/payload/Library/Scripts/Install or Defer.sh
+++ b/payload/Library/Scripts/Install or Defer.sh
@@ -12,7 +12,7 @@
 #                   in that update check, the system restarts automatically.
 #         Authors:  Mario Panighetti and Elliot Jordan
 #         Created:  2017-03-09
-#   Last Modified:  2021-03-09
+#   Last Modified:  2021-03-10
 #         Version:  4.1
 #
 ###
@@ -245,6 +245,9 @@ run_updates () {
             CURRENT_USER=$(/usr/bin/stat -f%Su "/dev/console")
             USER_ID=$(/usr/bin/id -u "$CURRENT_USER")
             /bin/launchctl asuser "$USER_ID" open "/System/Library/PreferencePanes/SoftwareUpdate.prefPane"
+
+            # Leave the alert up for 60 seconds before looping.
+            sleep 60
 
             # Clear out jamfHelper alert before looping to prevent pileups.
             echo "Killing any active jamfHelper notifications..."

--- a/payload/Library/Scripts/Install or Defer.sh
+++ b/payload/Library/Scripts/Install or Defer.sh
@@ -12,8 +12,8 @@
 #                   in that update check, the system restarts automatically.
 #         Authors:  Mario Panighetti and Elliot Jordan
 #         Created:  2017-03-09
-#   Last Modified:  2021-03-08
-#         Version:  4.0.3
+#   Last Modified:  2021-03-09
+#         Version:  4.1
 #
 ###
 

--- a/payload/Library/Scripts/Install or Defer.sh
+++ b/payload/Library/Scripts/Install or Defer.sh
@@ -428,6 +428,9 @@ else
 fi
 echo "Maximum deferral time: $(convert_seconds "$MAX_DEFERRAL_TIME")"
 
+# Check for updates, exit if none found, otherwise cache locally and continue.
+check_for_updates
+
 # Perform first run tasks, including calculating deadline.
 FORCE_DATE=$(/usr/bin/defaults read "$PLIST" UpdatesForcedAfter 2>"/dev/null")
 if [[ -z $FORCE_DATE || $FORCE_DATE -gt $(( $(/bin/date +%s) + MAX_DEFERRAL_TIME )) ]]; then
@@ -449,9 +452,6 @@ if [[ -n "$DEFERRED_UNTIL" ]] && (( DEFERRED_UNTIL > $(/bin/date +%s) && FORCE_D
     echo "The next prompt is deferred until after $(/bin/date -jf "%s" "+%Y-%m-%d %H:%M:%S" "$DEFERRED_UNTIL")."
     exit 0
 fi
-
-# Check for updates, exit if none found, otherwise cache locally and continue.
-check_for_updates
 
 # Make a note of the time before displaying the prompt.
 PROMPT_START=$(/bin/date +%s)

--- a/payload/Library/Scripts/Install or Defer.sh
+++ b/payload/Library/Scripts/Install or Defer.sh
@@ -12,8 +12,8 @@
 #                   the system restarts automatically.
 #         Authors:  Mario Panighetti and Elliot Jordan
 #         Created:  2017-03-09
-#   Last Modified:  2020-12-08
-#         Version:  4.0.1
+#   Last Modified:  2020-12-14
+#         Version:  4.0.2
 #
 ###
 
@@ -400,8 +400,15 @@ fi
 # Validate logo file. If no logo is provided or if the file cannot be found at
 # specified path, default to the Software Update icon.
 if [[ -z "$LOGO" ]] || [[ ! -f "$LOGO" ]]; then
-    echo "No logo provided, or no logo exists at specified path. Using Software Update icon."
-    LOGO="/System/Library/CoreServices/Software Update.app/Contents/Resources/SoftwareUpdate.icns"
+    echo "No logo provided, or no image file exists at specified path. Using Software Update icon."
+    # macOS High Sierra is the only supported macOS that does not have a
+    # Software Update preference pane, so we'll use the Software Update.app
+    # icon instead.
+    if [[ "$OS_MAJOR" -eq 10 && "$OS_MINOR" -eq 13 ]]; then
+      LOGO="/System/Library/CoreServices/Software Update.app/Contents/Resources/SoftwareUpdate.icns"
+    else
+      LOGO="/System/Library/PreferencePanes/SoftwareUpdate.prefPane/Contents/Resources/SoftwareUpdate.icns"
+    fi
 fi
 
 # Validate max deferral time and whether to skip deferral. To customize these

--- a/payload/Library/Scripts/Install or Defer.sh
+++ b/payload/Library/Scripts/Install or Defer.sh
@@ -12,7 +12,7 @@
 #                   the system restarts automatically.
 #         Authors:  Mario Panighetti and Elliot Jordan
 #         Created:  2017-03-09
-#   Last Modified:  2020-12-17
+#   Last Modified:  2021-03-08
 #         Version:  4.0.3
 #
 ###
@@ -49,24 +49,26 @@ SCRIPT_PATH="/Library/Scripts/Install or Defer.sh"
 
 # The message users will receive when updates are available, shown above the
 # "Run Updates" and "Defer" buttons.
-MSG_ACT_OR_DEFER_HEADING="Critical updates are available"
-MSG_ACT_OR_DEFER="Your Mac needs to run critical security updates<< which require a restart>>:
+MSG_ACT_OR_DEFER_HEADING="Updates are available"
+MSG_ACT_OR_DEFER="Your Mac needs to run the following updates<< which require a restart>>:
 
 UPDATE_LIST
 
 Please save your work, quit all applications, and click Run Updates. {{If now is not a good time, you may defer this message until later. }}Updates will install automatically after %DEFER_HOURS% hours<<, forcing your Mac to restart in the process>>.
 
-If you have any questions, please contact IT."
+Please contact IT for any questions."
 
 # The message users will receive after the deferral deadline has been reached.
 MSG_ACT_HEADING="Please run updates now"
-MSG_ACT="Please save your work, then run all available macOS security updates<< (restart your Mac when prompted)>>. If no action is taken, these updates will be installed automatically:
+MSG_ACT="Your Mac is about to run the following updates<< and restart>>:
 
-UPDATE_LIST"
+UPDATE_LIST
+
+Please save your work and quit any of the above applications. You can manually run macOS updates in System Preferences > Softare Update."
 
 # The message users will receive while updates are running in the background.
 MSG_UPDATING_HEADING="Running updates"
-MSG_UPDATING="Running the following macOS updates in the background<< (your Mac will restart automatically when this is finished)>>:
+MSG_UPDATING="Running the following updates in the background<< (your Mac will restart automatically when this is finished)>>:
 
 UPDATE_LIST"
 
@@ -109,15 +111,16 @@ convert_seconds () {
 
 }
 
-# Caches all available critical system updates, or exits if no critical updates
-# are available.
+# Checks for recommended macOS updates, or exits if no such updates are
+# available.
 check_for_updates () {
 
     echo "Checking for pending system updates..."
     UPDATE_CHECK=$(/usr/sbin/softwareupdate --list 2>&1)
 
-    # Determine whether any critical updates are available.
-    # If a restart is required, run all available updates.
+    # Determine whether any recommended macOS updates are available.
+    # If a restart is required for any pending updates, then run all available
+    # software updates.
     if [[ "$UPDATE_CHECK" =~ (Action: restart|\[restart\]) ]]; then
         INSTALL_WHICH="all"
         RESTART_FLAG="--restart"
@@ -135,9 +138,9 @@ check_for_updates () {
         MSG_ACT_OR_DEFER="$(echo "$MSG_ACT_OR_DEFER" | /usr/bin/sed 's/\<\<.*\>\>//g')"
         MSG_ACT="$(echo "$MSG_ACT" | /usr/bin/sed 's/\<\<.*\>\>//g')"
         MSG_UPDATING="$(echo "$MSG_UPDATING" | /usr/bin/sed 's/\<\<.*\>\>//g')"
-    # If no updates need to be installed, bail out.
+    # If no recommended updates need to be installed, bail out.
     else
-        echo "No critical updates available."
+        echo "No recommended updates available."
         exit_without_updating
     fi
 


### PR DESCRIPTION
- added comma-separated list of pending software updates to display in user-facing dialog boxes
- added basic Apple Silicon architecture support #45
  - script prompts for manual update action, opens System Preferences - Software Update, and repeats until no recommended updates are detected or the system is restarted
- moved `check_for_updates` run before `FORCE_DATE` check (prevents the deferral countdown clock from starting until after update cache has finished on first script run)
- switched default logo path to use `/System/Library/PreferencePanes/SoftwareUpdate.prefPane/Contents/Resources/SoftwareUpdate.icns` (Big Sur does not have an icon for the Software Update app)
