### PR TITLE
added deadline date to alert messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,14 @@ There are several settings in the script that can be customized by changing defa
 
 #### Messaging
 
+- `INSTALL_BUTTON`
+
+    The label of the install button.
+
+- `DEFER_BUTTON`
+
+    The label of the defer button.
+
 - `MSG_ACT_OR_DEFER_HEADING`
 
     The heading/title of the message users will receive when updates are available.
@@ -122,6 +130,14 @@ There are several settings in the script that can be customized by changing defa
 
     The body of the message users will receive when they must run updates immediately.
 
+- `MSG_ACT_NOW_HEADING`
+
+    The heading/title of the message users will receive when a manual update action is required.
+
+- `MSG_ACT_NOW`
+
+    The body of the message users will receive when a manual update action is required.
+
 - `MSG_UPDATING_HEADING`
 
     The heading/title of the message users will receive when updates are running in the background.
@@ -132,9 +148,11 @@ There are several settings in the script that can be customized by changing defa
 
 The above messages use the following dynamic substitutions:
 
-- `%DEFER_HOURS%` will be automatically replaced by the number of hours remaining in the deferral period.
-- The section in the `<<double comparison operators>>` will be removed if a restart is not required.
+- `%UPDATE_LIST%` will be automatically replaced with a comma-separated list of all recommended updates found in a Software Update check.
+- `%DEFER_HOURS%` will be automatically replaced by the number of days, hours, or minutes remaining in the deferral period.
+- `%DEADLINE_DATE%` will be automatically replaced by the deadline date and time before updates are enforced.
 - The section in the `{{double curly brackets}}` will be removed when this message is displayed for the final time before the deferral deadline.
+- The section in the `<<double comparison operators>>` will be removed if a restart is not required.
 
 #### Timing
 

--- a/build-info.plist
+++ b/build-info.plist
@@ -17,6 +17,6 @@
 	<key>suppress_bundle_relocation</key>
 	<true/>
 	<key>version</key>
-	<string>4.1.2</string>
+	<string>4.1.3</string>
 </dict>
 </plist>

--- a/payload/Library/Scripts/Install or Defer.sh
+++ b/payload/Library/Scripts/Install or Defer.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC2001
 
 ###
 #
@@ -170,11 +171,11 @@ check_for_updates () {
     UPDATE_LIST="$(echo "$UPDATE_LIST" | /usr/bin/tr '\n' ',' | /usr/bin/sed 's/^ *//; s/,/, /g; s/, $//')"
     # Reformat update list to replace last comma with ", and" or " and" as
     # needed for legibility. In this house, we use Oxford commas.
-    COMMA_COUNT=$(echo "$UPDATE_LIST" | /usr/bin/tr -dc ',' | /usr/bin/wc -c | /usr/bin/bc)
+    COMMA_COUNT="$(echo "$UPDATE_LIST" | /usr/bin/tr -dc ',' | /usr/bin/wc -c | /usr/bin/bc)"
     if [ "$COMMA_COUNT" -gt 1 ]; then
-        UPDATE_LIST=$(echo "$UPDATE_LIST" | sed 's/\(.*\),/\1, and/')
+        UPDATE_LIST="$(echo "$UPDATE_LIST" | sed 's/\(.*\),/\1, and/')"
     elif [ "$COMMA_COUNT" -eq 1 ]; then
-        UPDATE_LIST=$(echo "$UPDATE_LIST" | sed 's/\(.*\),/\1 and/')
+        UPDATE_LIST="$(echo "$UPDATE_LIST" | sed 's/\(.*\),/\1 and/')"
     fi
     # Populate the list of pending updates in message text.
     MSG_ACT_OR_DEFER="$(echo "$MSG_ACT_OR_DEFER" | /usr/bin/sed "s/%UPDATE_LIST%/$UPDATE_LIST/")"

--- a/payload/Library/Scripts/Install or Defer.sh
+++ b/payload/Library/Scripts/Install or Defer.sh
@@ -520,6 +520,10 @@ if (( DEFER_TIME_LEFT > 0 )); then
         MSG_ACT_OR_DEFER="${MSG_ACT_OR_DEFER//after %DEFER_HOURS% hours/very soon}"
     fi
 
+    # Substitute the deadline date.
+    MSG_ACT_OR_DEFER="${MSG_ACT_OR_DEFER//%DEADLINE_DATE%/$(/bin/date -jf "%s" "+%b %d, %Y at %I:%M%p" "$FORCE_DATE")}"
+    MSG_ACT_OR_DEFER_HEADING="${MSG_ACT_OR_DEFER_HEADING//%DEADLINE_DATE%/$(/bin/date -jf "%s" "+%b %d, %Y" "$FORCE_DATE")}"
+
     # Determine whether to include the "you may defer" wording.
     if (( EACH_DEFER > DEFER_TIME_LEFT )); then
         # Remove "{{" and "}}" including all the text between.


### PR DESCRIPTION
- added optional deadline date display in alert messaging
- reformatted comma-separated update list to be grammatically correct for inline placement (uses Oxford comma when >2 items are listed)
- updated messaging to display update list inline and condense text into fewer lines
- NEXT_PROMPT is now set to FORCE_DATE if it's sooner than the calculated deferral time
- switched update list placeholder string to match others
- updated README with recent messaging and button changes