### PR TITLE
added com.apple.softwareupdated kickstart

### DIFF
--- a/build-info.plist
+++ b/build-info.plist
@@ -17,6 +17,6 @@
 	<key>suppress_bundle_relocation</key>
 	<true/>
 	<key>version</key>
-	<string>4.1.7</string>
+	<string>4.1.8</string>
 </dict>
 </plist>


### PR DESCRIPTION
- added function to kickstart the `com.apple.softwareupdated` service (needed to work around a macOS Big Sur+ bug where update checks hang indefinitely or incorrectly report no updates available #54)
  - function runs before every run of the `softwareupdate` binary