### PR TITLE
added new configuration profile keys and macOS Monterey support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,29 @@ This framework is designed to work "out of the box" without any modification, bu
 
 You can customize some values using a configuration profile targeting the `$BUNDLE_ID` preference domain. This allows you to apply different configurations to different groups of Macs (e.g. a dedicated test group could have shorter deferral times), and lets you make changes to these settings on the fly without repackaging and redeploying the script. The following keys can be defined via configuration profile:
 
+- `DeferButtonLabel`
+
+    **String**. The label of the defer button. Defaults to "Defer".
+
+- `InstallButtonLabel`
+
+    **String**. The label of the install button. Defaults to "Install".
+
 - `MaxDeferralTime`
 
     **Integer**. Number of seconds between the first script run and the updates being enforced. Defaults to `259200` (3 days).
 
+- `MessagingLogo`
+
+    **String**. File path to a logo that will be used in messaging. Recommend 512px, PNG format. Defaults to the Software Update icon.
+
 - `SkipDeferral`
 
     **Boolean**. Whether to bypass deferral time entirely and skip straight to update enforcement (useful for script testing purposes). Defaults to `false`.
+
+- `WorkdayStartHour` and `WorkdayEndHour`
+
+    **Integers**. (optional) The hours that a workday starts and ends in your organization. These values must each be an integer between 0 and 23, and the end hour must be later than the start hour. If the update deadline falls within this window of time, it will be moved forward to occur at the end of the workday.
 
 ### Script variables
 
@@ -89,10 +105,6 @@ There are several settings in the script that can be customized by changing defa
 
     Path to a plist file that is used to store settings locally. Omit ".plist" extension.
 
-- `LOGO`
-
-    (Optional) Path to a logo that will be used in messaging. Recommend 512px, PNG format. If no logo is provided, the Software Update icon will be used (as shown in the example screenshots in this README).
-
 - `BUNDLE_ID`
 
     The identifier of the LaunchDaemon that is used to call this script, which should match the file in the __payload/Library/LaunchDaemons__ folder. Omit ".plist" extension.
@@ -102,14 +114,6 @@ There are several settings in the script that can be customized by changing defa
     The file path of the `Install or Defer.sh` script. Used in the script to assist with resource file clean-up.
 
 #### Messaging
-
-- `INSTALL_BUTTON`
-
-    The label of the install button.
-
-- `DEFER_BUTTON`
-
-    The label of the defer button.
 
 - `MSG_ACT_OR_DEFER_HEADING`
 
@@ -164,10 +168,6 @@ The above messages use the following dynamic substitutions:
 - `HARD_RESTART_DELAY`
 
     The number of seconds to wait between attempting a soft restart and forcing a restart.
-
-- `WORKDAY_START_HR` and `WORKDAY_END_HR`
-
-    (optional) The hours that a workday starts and ends in your organization. These values must each be an integer between 0 and 23, and the end hour must be later than the start hour. If the update deadline falls within this window of time, it will be moved forward to occur at the end of the workday. If you want to use this functionality, uncomment both variables and set your desired values.
 
 
 ### Installer creation
@@ -322,9 +322,9 @@ Once the Testing steps above have been followed, there are only a few steps rema
 
 If major problems are detected with the update prompt or installation workflow, disable the __Install or Defer__ policy. This will prevent computers from being newly prompted for installation of updates.
 
-Note that any computers which have already received the framework push will continue through the motions of alerting, deferring, updating, and restarting. If you need to remove the framework from your fleet and stop it from running, you could write an uninstall script using the preinstall script as a foundation (it would basically just need to unload the LaunchDaemons and remove the resource files).
+Note that any computers which have already received the framework push will continue through the motions of alerting, deferring, updating, and restarting. If you need to remove the framework from your fleet and stop it from running, you could write an uninstall script using the `preinstall` script as a foundation (it would basically just need to unload the LaunchDaemons and remove the resource files).
 
-Once the script is debugged and updated, you can generate a new installer package, upload the package to the Jamf Pro server, link it to the policy, and re-enable the policy. The preinstall script will remove any existing resources and replace them with your modified files.
+Once the script is debugged and updated, you can generate a new installer package, upload the package to the Jamf Pro server, link it to the policy, and re-enable the policy. The `preinstall` script will remove any existing resources and replace them with your modified files.
 
 
 ## Troubleshooting
@@ -341,10 +341,9 @@ sudo chmod 644 /path/to/install-or-defer/payload/Library/LaunchDaemons/com.githu
 
 ## Miscellaneous Notes
 
-- Feel free to change the `com.github.mpanighetti` bundle identifier to match your company instead. If you do this, make sure to update the filenames of the LaunchDaemons, their corresponding file paths in the preinstall and postinstall scripts, and the `$BUNDLE_ID` variable in the script.
-- You can specify a different default logo if you'd rather not use the Software Update icon (e.g. corporate branding). `jamfHelper` supports .icns and .png files.
+- Feel free to change the `com.github.mpanighetti` bundle identifier to match your company instead. If you do this, make sure to update the filenames of the LaunchDaemons, their corresponding file paths in the `preinstall` and `postinstall` scripts, the `$BUNDLE_ID` variable in the script, and the bundle identifier used for settings enforced via configuration profile.
 - If you encounter any issues or have questions, please open an issue on this GitHub repo.
 
 Enjoy!
 
-<a name="footnote1"><sup>1</sup></a> This example frequency assumes you're using the default deferral period of 72 hours. If you've set a custom deferral period, it is recommended that your policy runs less frequently than the maximum deferral time, so that your Macs have the chance to defer, timeout, and apply the updates before the policy attempts to run again (since the preinstall script will reset `UpdatesDeferredUntil` and `UpdatesForcedAfter`).
+<a name="footnote1"><sup>1</sup></a> This example frequency assumes you're using the default deferral period of 72 hours. If you've set a custom deferral period, it is recommended that your policy runs less frequently than the maximum deferral time, so that your Macs have the chance to defer, timeout, and apply the updates before the policy attempts to run again (since the `preinstall` script will reset `UpdatesDeferredUntil` and `UpdatesForcedAfter`).

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This framework is designed to work "out of the box" without any modification, bu
 
 ### Configuration profile
 
-You can customize some values using a configuration profile targeting the `$BUNDLE_ID` preference domain. This allows you to apply different configurations to different groups of Macs (e.g. a dedicated test group could have shorter deferral times), and lets you make changes to these settings on the fly without repackaging and redeploying the script. The following keys can be defined via configuration profile:
+You can customize many settings using a configuration profile targeting the `$BUNDLE_ID` preference domain. This allows you to apply different configurations to different groups of Macs (e.g. a dedicated test group could have shorter deferral times), and lets you make changes to these settings on the fly without repackaging and redeploying the script. The following settings can be defined via configuration profile keys:
 
 - `InstallButtonLabel` and `DeferButtonLabel`
 
@@ -111,7 +111,7 @@ There are several settings in the script that can be customized by changing defa
 
 - `BUNDLE_ID`
 
-    The identifier of the LaunchDaemon that is used to call this script, which should match the file in the __payload/Library/LaunchDaemons__ folder. Omit ".plist" extension.
+    The identifier of the LaunchDaemon that is used to call the `Install or Defer.sh` script, which should match the file name in the __payload/Library/LaunchDaemons__ folder. Omit ".plist" extension.
 
 - `SCRIPT_PATH`
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,10 @@ The above messages use the following dynamic substitutions:
 
     When the user clicks "Defer" the next prompt is delayed by this much time.
 
+- `PROMPT_TIMEOUT`
+
+    The number of seconds to wait before timing out each Install or Defer prompt. This value should be less than the `EACH_DEFER` value.
+
 - `UPDATE_DELAY`
 
     The number of seconds to wait between displaying the "run updates" message and applying updates, then attempting a soft restart.

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ You can customize some values using a configuration profile targeting the `$BUND
 
     **Boolean**. Whether to bypass deferral time entirely and skip straight to update enforcement (useful for script testing purposes). Defaults to `false`.
 
+- `SupportContact`
+
+    **String**. Contact information for technical support included in messaging alerts. Recommend using a team name (e.g. "Technical Support"), email address (e.g. "support@contoso.com"), or chat channel (e.g. "#technical-support"). Defaults to "IT".
+
 - `WorkdayStartHour` and `WorkdayEndHour`
 
     **Integers**. (optional) The hours that a workday starts and ends in your organization. These values must each be an integer between 0 and 23, and the end hour must be later than the start hour. If the update deadline falls within this window of time, it will be moved forward to occur at the end of the workday.
@@ -115,27 +119,27 @@ There are several settings in the script that can be customized by changing defa
 
 #### Messaging
 
-- `MSG_ACT_OR_DEFER_HEADING`
+- `MSG_INSTALL_OR_DEFER_HEADING`
 
     The heading/title of the message users will receive when updates are available.
 
-- `MSG_ACT_OR_DEFER`
+- `MSG_INSTALL_OR_DEFER`
 
     The body of the message users will receive when updates are available.
 
-- `MSG_ACT_HEADING`
+- `MSG_INSTALL_HEADING`
 
     The heading/title of the message users will receive when they must run updates immediately.
 
-- `MSG_ACT`
+- `MSG_INSTALL`
 
     The body of the message users will receive when they must run updates immediately.
 
-- `MSG_ACT_NOW_HEADING`
+- `MSG_INSTALL_NOW_HEADING`
 
     The heading/title of the message users will receive when a manual update action is required.
 
-- `MSG_ACT_NOW`
+- `MSG_INSTALL_NOW`
 
     The body of the message users will receive when a manual update action is required.
 

--- a/README.md
+++ b/README.md
@@ -153,11 +153,12 @@ There are several settings in the script that can be customized by changing defa
 
 The above messages use the following dynamic substitutions:
 
-- `%UPDATE_LIST%` will be automatically replaced with a comma-separated list of all recommended updates found in a Software Update check.
+- `%DEADLINE_DATE%` will be automatically replaced with the deadline date and time before updates are enforced.
 - `%DEFER_HOURS%` will be automatically replaced by the number of days, hours, or minutes remaining in the deferral period.
-- `%DEADLINE_DATE%` will be automatically replaced by the deadline date and time before updates are enforced.
+- `%SUPPORT_CONTACT%` will be automatically replaced with "IT" or a custom value set via configuration profile key.
+- `%UPDATE_LIST%` will be automatically replaced with a comma-separated list of all recommended updates found in a Software Update check.
 - The section in the `{{double curly brackets}}` will be removed when this message is displayed for the final time before the deferral deadline.
-- The section in the `<<double comparison operators>>` will be removed if a restart is not required.
+- The sections in the `<<double comparison operators>>` will be removed if a restart is not required for the pending updates.
 
 #### Timing
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ You can customize some values using a configuration profile targeting the `$BUND
 
 - `InstallButtonLabel` and `DeferButtonLabel`
 
-    **Strings**. The labels of the install and defer buttons. Default to "Install" and "Defer" respectively. Keep these strings short since `jamfHelper` will cut off longer labels.
+    **Strings**. The labels of the install and defer buttons. Default to "Install" and "Defer" respectively. Keep these strings short since `jamfHelper` will cut off longer button labels.
 
 - `DiagnosticLog`
 

--- a/README.md
+++ b/README.md
@@ -71,13 +71,13 @@ This framework is designed to work "out of the box" without any modification, bu
 
 You can customize some values using a configuration profile targeting the `$BUNDLE_ID` preference domain. This allows you to apply different configurations to different groups of Macs (e.g. a dedicated test group could have shorter deferral times), and lets you make changes to these settings on the fly without repackaging and redeploying the script. The following keys can be defined via configuration profile:
 
-- `DeferButtonLabel`
+- `InstallButtonLabel` and `DeferButtonLabel`
 
-    **String**. The label of the defer button. Defaults to "Defer".
+    **Strings**. The labels of the install and defer buttons. Default to "Install" and "Defer" respectively. Keep these strings short since `jamfHelper` will cut off longer labels.
 
-- `InstallButtonLabel`
+- `DiagnosticLog`
 
-    **String**. The label of the install button. Defaults to "Install".
+    **Boolean**. Whether to write to a persistent log file at `/var/log/install-or-defer.log`. Defaults to `false`, instead writing all output to the system log for live diagnostics.
 
 - `MaxDeferralTime`
 

--- a/build-info.plist
+++ b/build-info.plist
@@ -17,6 +17,6 @@
 	<key>suppress_bundle_relocation</key>
 	<true/>
 	<key>version</key>
-	<string>4.1.8</string>
+	<string>5.0</string>
 </dict>
 </plist>

--- a/payload/Library/Scripts/Install or Defer.sh
+++ b/payload/Library/Scripts/Install or Defer.sh
@@ -40,14 +40,14 @@ SCRIPT_PATH="/Library/Scripts/Install or Defer.sh"
 ################################## MESSAGING ##################################
 
 # The messages below use the following dynamic substitutions wherever found:
-#   - %UPDATE_LIST% will be automatically replaced with a comma-separated list
-#     of all recommended updates found in a Software Update check.
-#   - %DEFER_HOURS% will be automatically replaced by the number of days, hours,
-#     or minutes remaining in the deferral period.
 #   - %DEADLINE_DATE% will be automatically replaced with the deadline date and
 #     time before updates are enforced.
-#   - %SUPPORT_CONTACT% wil be automatically replaced with "IT" or a custom
+#   - %DEFER_HOURS% will be automatically replaced by the number of days, hours,
+#     or minutes remaining in the deferral period.
+#   - %SUPPORT_CONTACT% will be automatically replaced with "IT" or a custom
 #     value set via configuration profile key.
+#   - %UPDATE_LIST% will be automatically replaced with a comma-separated list
+#     of all recommended updates found in a Software Update check.
 #   - The section in the {{double curly brackets}} will be removed when this
 #     message is displayed for the final time before the deferral deadline.
 #   - The sections in the <<double comparison operators>> will be removed if a

--- a/payload/Library/Scripts/Install or Defer.sh
+++ b/payload/Library/Scripts/Install or Defer.sh
@@ -15,8 +15,8 @@
 #                   https://github.com/mpanighetti/install-or-defer
 #         Authors:  Mario Panighetti and Elliot Jordan
 #         Created:  2017-03-09
-#   Last Modified:  2022-01-27
-#         Version:  4.1.8
+#   Last Modified:  2022-01-31
+#         Version:  5.0
 #
 ###
 
@@ -26,10 +26,6 @@
 # Path to a plist file that is used to store settings locally. Omit ".plist"
 # extension.
 PLIST="/Library/Preferences/com.github.mpanighetti.install-or-defer"
-
-# (Optional) Path to a logo that will be used in messaging. Recommend 512px,
-# PNG format. If no logo is provided, the Software Update icon will be used.
-LOGO=""
 
 # The identifier of the LaunchDaemon that is used to call this script, which
 # should match the file in the payload/Library/LaunchDaemons folder. Omit
@@ -41,12 +37,6 @@ SCRIPT_PATH="/Library/Scripts/Install or Defer.sh"
 
 
 ################################## MESSAGING ##################################
-
-# The label of the install button.
-INSTALL_BUTTON="Install"
-
-# The label of the defer button.
-DEFER_BUTTON="Defer"
 
 # The messages below use the following dynamic substitutions wherever found:
 #   - %UPDATE_LIST% will be automatically replaced with a comma-separated list
@@ -65,7 +55,7 @@ DEFER_BUTTON="Defer"
 MSG_ACT_OR_DEFER_HEADING="Updates are available"
 MSG_ACT_OR_DEFER="Your Mac needs to run updates for %UPDATE_LIST% by %DEADLINE_DATE%.
 
-Please save your work, quit any of the above applications, and click ${INSTALL_BUTTON}. {{If now is not a good time, you may click ${DEFER_BUTTON} to delay this message until later. }}These updates will be required after %DEFER_HOURS%<<, forcing your Mac to restart after they run>>.
+Please save your work, quit any applications listed above, and run all available updates. {{If now is not a good time, you may defer to delay this message until later. }}These updates will be required after %DEFER_HOURS%<<, forcing your Mac to restart after they run>>.
 
 Please contact IT for any questions."
 
@@ -73,7 +63,7 @@ Please contact IT for any questions."
 MSG_ACT_HEADING="Please run updates now"
 MSG_ACT="Your Mac is about to run updates for %UPDATE_LIST% << and restart>>.
 
-Please save your work, quit any of the above applications, and click ${INSTALL_BUTTON} before the deadline.<< Your Mac will restart when all updates are finished running.>>
+Please save your work, quit any applications listed above, and run all available updates before the deadline.<< Your Mac will restart when all updates are finished running.>>
 
 Please contact IT for any questions."
 
@@ -81,7 +71,7 @@ Please contact IT for any questions."
 MSG_ACT_NOW_HEADING="Updates are available"
 MSG_ACT_NOW="Your Mac needs to run updates for %UPDATE_LIST% << which require a restart>>.
 
-Please save your work, quit any of the above applications, then open System Preferences -> Software Update and run all available updates.<< Your Mac will restart when all updates are finished running.>>"
+Please save your work, quit any applications listed above, then open System Preferences -> Software Update and run all available updates.<< Your Mac will restart when all updates are finished running.>>"
 
 # The message users will receive while updates are running in the background.
 MSG_UPDATING_HEADING="Running updates..."
@@ -89,9 +79,6 @@ MSG_UPDATING="Running updates for %UPDATE_LIST% in the background.<< Your Mac wi
 
 
 #################################### TIMING ###################################
-
-# Number of seconds between the first script run and the updates being forced.
-MAX_DEFERRAL_TIME=$(( 60 * 60 * 24 * 3 )) # (259200 = 3 days)
 
 # When the user clicks "Defer" the next prompt is delayed by this much time.
 EACH_DEFER=$(( 60 * 60 * 4 )) # (14400 = 4 hours)
@@ -104,14 +91,42 @@ UPDATE_DELAY=$(( 60 * 10 )) # (600 = 10 minutes)
 # restart.
 HARD_RESTART_DELAY=$(( 60 * 5 )) # (300 = 5 minutes)
 
+
+######################## CONFIGURATION PROFILE SETTINGS #######################
+
+# Checks for whether any custom settings have been applied via a configuration
+# profile, in order to override script defaults with these custom values. To
+# customize these values, make a configuration profile for $BUNDLE_ID and make
+# new selections for each specified key.
+#
+# - InstallButtonLabel (String). The label of the install button. Defaults to
+# "Install".
+# - DeferButtonLabel (String). The label of the defer button. Defaults to
+# "Defer".
+# - MaxDeferralTime (Integer). Number of seconds between the first script run
+# and the updates being enforced. Defaults to 259200 (3 days).
+# - MessagingLogo (String). File path to a logo that will be used in messaging.
+# Recommend 512px, PNG format. Defaults to the Software Update icon.
+# - SkipDeferral (Boolean). Whether to bypass deferral time entirely and skip
+# straight to update enforcement (useful for script testing purposes). Defaults
+# to False. If set to True, this setting supersedes any values set for
+# MaxDeferralTime.
+#
 # (optional) The hours that a workday starts and ends in your organization.
 # These values must each be an integer between 0 and 23, and the end hour must
 # be later than the start hour. If the update deadline falls within this window
-# of time, it will be moved forward to occur at the end of the workday. If you
-# want to use this functionality, uncomment both variables and set your desired
-# values.
-#WORKDAY_START_HR=9
-#WORKDAY_END_HR=17
+# of time, it will be moved forward to occur at the end of the workday.
+# - WorkdayStartHour (Integer). The hour that a workday starts in your
+# organization.
+# - WorkdayEndHour (Integer). The hour that a workday ends in your organization.
+
+DEFER_BUTTON_CUSTOM=$(/usr/bin/defaults read "/Library/Managed Preferences/${BUNDLE_ID}" DeferButtonLabel 2>"/dev/null")
+INSTALL_BUTTON_CUSTOM=$(/usr/bin/defaults read "/Library/Managed Preferences/${BUNDLE_ID}" InstallButtonLabel 2>"/dev/null")
+MAX_DEFERRAL_TIME_CUSTOM=$(/usr/bin/defaults read "/Library/Managed Preferences/${BUNDLE_ID}" MaxDeferralTime 2>"/dev/null")
+MESSAGING_LOGO_CUSTOM=$(/usr/bin/defaults read "/Library/Managed Preferences/${BUNDLE_ID}" MessagingLogo 2>"/dev/null")
+SKIP_DEFERRAL_CUSTOM=$(/usr/bin/defaults read "/Library/Managed Preferences/${BUNDLE_ID}" SkipDeferral 2>"/dev/null")
+WORKDAY_END_HR_CUSTOM=$(/usr/bin/defaults read "/Library/Managed Preferences/${BUNDLE_ID}" WorkdayEndHour 2>"/dev/null")
+WORKDAY_START_HR_CUSTOM=$(/usr/bin/defaults read "/Library/Managed Preferences/${BUNDLE_ID}" WorkdayStartHour 2>"/dev/null")
 
 
 ################################## FUNCTIONS ##################################
@@ -417,20 +432,20 @@ fi
 OS_MAJOR=$(/usr/bin/sw_vers -productVersion | /usr/bin/awk -F . '{print $1}')
 OS_MINOR=$(/usr/bin/sw_vers -productVersion | /usr/bin/awk -F . '{print $2}')
 
-# This script has currently been tested in macOS 10.13+ and macOS 11,
-# and will exit with error for any other macOS versions.
+# This script has currently been tested in macOS 10.14+, macOS 11, and macOS 12.
+# It will exit with error for any other macOS versions.
 # When new versions of macOS are released, this logic should be updated after
 # the script has been tested successfully.
-if [[ "$OS_MAJOR" -lt 10 ]] || [[ "$OS_MAJOR" -eq 10 && "$OS_MINOR" -lt 13 ]] || [[ "$OS_MAJOR" -gt 11 ]]; then
-    echo "❌ ERROR: This script supports macOS 10.13+ and macOS 11, but this Mac is running macOS ${OS_MAJOR}.${OS_MINOR}, unable to proceed."
+if [[ "$OS_MAJOR" -lt 10 ]] || [[ "$OS_MAJOR" -eq 10 && "$OS_MINOR" -lt 14 ]] || [[ "$OS_MAJOR" -gt 12 ]]; then
+    echo "❌ ERROR: This script supports macOS 10.14+, macOS 11, and macOS 12, but this Mac is running macOS ${OS_MAJOR}.${OS_MINOR}, unable to proceed."
     BAILOUT="true"
 fi
 
 # Determine platform architecture.
-PLATFORM_ARCH=$(/usr/bin/arch)
+PLATFORM_ARCH="$(/usr/bin/arch)"
 
 # We need to be connected to the internet in order to download updates.
-if nc -zw1 swscan.apple.com 443; then
+if nc -zw1 "swscan.apple.com" 443; then
     # Check if a custom CatalogURL is set and if it is available
     # (deprecated in macOS 11+).
     if [[ "$OS_MAJOR" -lt 11 ]]; then
@@ -455,11 +470,11 @@ if /usr/bin/fdesetup status | /usr/bin/grep -q "in progress"; then
 fi
 
 # Validate workday start and end hours (if defined).
-if [[ -n "$WORKDAY_START_HR" ]] && [[ -n "$WORKDAY_END_HR" ]]; then
-    if (( 0 <= WORKDAY_START_HR && WORKDAY_START_HR < WORKDAY_END_HR && WORKDAY_END_HR < 24 )); then
-        echo "Workday: ${WORKDAY_START_HR}:00-${WORKDAY_END_HR}:00"
+if [[ -n "$WORKDAY_START_HR_CUSTOM" ]] && [[ -n "$WORKDAY_END_HR_CUSTOM" ]]; then
+    if (( 0 <= WORKDAY_START_HR_CUSTOM && WORKDAY_START_HR_CUSTOM < WORKDAY_END_HR_CUSTOM && WORKDAY_END_HR_CUSTOM < 24 )); then
+        echo "Workday: ${WORKDAY_START_HR_CUSTOM}:00-${WORKDAY_END_HR_CUSTOM}:00"
     else
-        echo "❌ ERROR: There is a logical disconnect between the workday start hour (${WORKDAY_START_HR}) and end hour (${WORKDAY_END_HR}). Please update these values to meet script requirements (start hour ≥ 0, start hour < end hour, end hour < 24)."
+        echo "❌ ERROR: There is a logical disconnect between the workday start hour (${WORKDAY_START_HR_CUSTOM}) and end hour (${WORKDAY_END_HR_CUSTOM}). Please update these values to meet script requirements (start hour ≥ 0, start hour < end hour, end hour < 24)."
         BAILOUT="true"
     fi
 fi
@@ -481,36 +496,46 @@ fi
 
 ################################ MAIN PROCESS #################################
 
-# Validate logo file. If no logo is provided or if the file cannot be found at
-# specified path, default to the Software Update preference pane icon.
-if [[ -z "$LOGO" ]] || [[ ! -f "$LOGO" ]]; then
-    echo "No logo provided, or no image file exists at specified path. Using Software Update icon."
-    # macOS High Sierra is the only supported macOS that does not have a
-    # Software Update prefPane, so we'll use the Software Update.app icon
-    # instead.
-    if [[ "$OS_MAJOR" -eq 10 && "$OS_MINOR" -eq 13 ]]; then
-        LOGO="/System/Library/CoreServices/Software Update.app/Contents/Resources/SoftwareUpdate.icns"
-    else
-        LOGO="/System/Library/PreferencePanes/SoftwareUpdate.prefPane/Contents/Resources/SoftwareUpdate.icns"
-    fi
+# Validate configuration profile-enforced settings or use script defaults accordingly.
+# Whether to use custom labels for the install/defer buttons (defaults to "Install" and "Defer").
+if [ -n "$INSTALL_BUTTON_CUSTOM" ]; then
+    INSTALL_BUTTON="$INSTALL_BUTTON_CUSTOM"
+else
+    echo "Install button label undefined by administrator. Using default value."
+    INSTALL_BUTTON="Install"
 fi
+echo "Install button label: ${INSTALL_BUTTON}"
+if [ -n "$DEFER_BUTTON_CUSTOM" ]; then
+    DEFER_BUTTON="$DEFER_BUTTON_CUSTOM"
+else
+    echo "Defer button label undefined by administrator. Using default value."
+    DEFER_BUTTON="Defer"
+fi
+echo "Defer button label: ${DEFER_BUTTON}"
 
-# Validate max deferral time and whether to skip deferral. To customize these
-# values, make a configuration profile enforcing the MaxDeferralTime (in
-# seconds) and SkipDeferral (boolean) attributes in $BUNDLE_ID to settings of
-# your choice.
-SKIP_DEFERRAL=$(/usr/bin/defaults read "/Library/Managed Preferences/${BUNDLE_ID}" SkipDeferral 2>"/dev/null")
-if [[ "$SKIP_DEFERRAL" = "True" ]]; then
+# Whether to skip deferral (defaults to false).
+if [ "$SKIP_DEFERRAL_CUSTOM" -eq 1 ]; then
     MAX_DEFERRAL_TIME=0
 else
-    MAX_DEFERRAL_TIME_CUSTOM=$(/usr/bin/defaults read "/Library/Managed Preferences/${BUNDLE_ID}" MaxDeferralTime 2>"/dev/null")
+    # Checks for a custom maximum deferral time, otherwise defaults to 3 days.
     if (( MAX_DEFERRAL_TIME_CUSTOM > 0 )); then
         MAX_DEFERRAL_TIME="$MAX_DEFERRAL_TIME_CUSTOM"
     else
-        echo "Max deferral time undefined, or not set to a positive integer. Using default value."
+        echo "Maximum deferral time preference undefined by administrator, or not set to a positive integer. Using default value."
+        MAX_DEFERRAL_TIME=$(( 60 * 60 * 24 * 3 )) # (259200 seconds = 3 days)
     fi
 fi
 echo "Maximum deferral time: $(convert_seconds "$MAX_DEFERRAL_TIME")"
+
+# Checks for a custom messaging logo image, otherwise defaults to the Software
+# Update preference pane icon.
+if [[ -n "$MESSAGING_LOGO_CUSTOM" ]] && [[ -f "$MESSAGING_LOGO_CUSTOM" ]]; then
+    MESSAGING_LOGO="$MESSAGING_LOGO_CUSTOM"
+else
+    echo "Messaging logo undefined by admininstrator, or not found at specified path. Using default value."
+    MESSAGING_LOGO="/System/Library/PreferencePanes/SoftwareUpdate.prefPane/Contents/Resources/SoftwareUpdate.icns"
+fi
+echo "Messaging logo: ${MESSAGING_LOGO}"
 
 # Check for updates, exit if none found, otherwise continue.
 check_for_updates
@@ -524,11 +549,11 @@ fi
 
 # If a workday start and end hour have been defined and the deadline currently
 # occurs during the workday, shift it forward to the end of the workday.
-if [[ -n "$WORKDAY_START_HR" ]] && [[ -n "$WORKDAY_END_HR" ]]; then
+if [ -n "$WORKDAY_START_HR_CUSTOM" ] && [ -n "$WORKDAY_END_HR_CUSTOM" ]; then
     FORCE_DATE_HR=$(/bin/date -jf "%s" "+%H" "$FORCE_DATE")
-    if [[ "$FORCE_DATE_HR" -ge "$WORKDAY_START_HR" ]] && [[ "$FORCE_DATE_HR" -lt "$WORKDAY_END_HR" ]]; then
+    if [ "$FORCE_DATE_HR" -ge "$WORKDAY_START_HR_CUSTOM" ] && [ "$FORCE_DATE_HR" -lt "$WORKDAY_END_HR_CUSTOM" ]; then
         FORCE_DATE_YMD=$(/bin/date -jf "%s" "+%Y-%m-%d" "$FORCE_DATE")
-        FORCE_DATE=$(/bin/date -jf "%Y-%m-%d %H:%M:%S" "+%s" "${FORCE_DATE_YMD} ${WORKDAY_END_HR}:00:00")
+        FORCE_DATE=$(/bin/date -jf "%Y-%m-%d %H:%M:%S" "+%s" "${FORCE_DATE_YMD} ${WORKDAY_END_HR_CUSTOM}:00:00")
         /usr/bin/defaults write "$PLIST" UpdatesForcedAfter -int "$FORCE_DATE"
         echo "Shifted deferral deadline forward to occur outside of workday."
     fi

--- a/payload/Library/Scripts/Install or Defer.sh
+++ b/payload/Library/Scripts/Install or Defer.sh
@@ -4,12 +4,13 @@
 ###
 #
 #            Name:  Install or Defer.sh
-#     Description:  This script, meant to be triggered periodically by a
-#                   LaunchDaemon, will prompt users to install Apple system
-#                   updates that the IT department has deemed "critical." Users
-#                   will have the option to install the listed updates or defer
-#                   for the established time period. After a specified amount
-#                   of time, the update will be forced on Intel Macs, and if
+#     Description:  This script prompts users to install Apple system updates
+#                   that the IT department has deemed "critical." Users will
+#                   have the option to install the listed updates or defer for
+#                   the established time period, with a LaunchDaemon
+#                   periodically triggering the script to rerun. After a
+#                   specified amount of time, the update will be forced on Intel
+#                   Macs and persistently alerted on Apple Silicon Macs, and if
 #                   updates requiring a restart were found in that update check,
 #                   the system restarts automatically.
 #                   https://github.com/mpanighetti/install-or-defer

--- a/payload/Library/Scripts/Install or Defer.sh
+++ b/payload/Library/Scripts/Install or Defer.sh
@@ -88,8 +88,8 @@ MSG_UPDATING="Installing updates for %UPDATE_LIST% in the background.<< Your Mac
 # When the user clicks "Defer" the next prompt is delayed by this much time.
 EACH_DEFER=$(( 60 * 60 * 4 )) # (14400 = 4 hours)
 
-# The number of seconds to wait before timing out each Install or Defer prompt.
-# This value should be less than the EACH_DEFER value.
+# Number of seconds to wait before timing out the Install or Defer prompt.
+# This value should be less than the $EACH_DEFER value.
 PROMPT_TIMEOUT=$(( 60 * 60 )) # (3600 = 1 hour)
 
 # The number of seconds to wait between displaying the "install updates" message
@@ -519,7 +519,7 @@ fi
 ################################ MAIN PROCESS #################################
 
 # Validate configuration profile-enforced settings or use script defaults accordingly.
-# Whether to use custom labels for the install/defer buttons (defaults to "Install" and "Defer").
+# Whether to use custom labels for the install/defer buttons (default to "Install" and "Defer").
 if [ -n "$INSTALL_BUTTON_CUSTOM" ]; then
     INSTALL_BUTTON="$INSTALL_BUTTON_CUSTOM"
 else

--- a/payload/Library/Scripts/Install or Defer.sh
+++ b/payload/Library/Scripts/Install or Defer.sh
@@ -88,6 +88,10 @@ MSG_UPDATING="Installing updates for %UPDATE_LIST% in the background.<< Your Mac
 # When the user clicks "Defer" the next prompt is delayed by this much time.
 EACH_DEFER=$(( 60 * 60 * 4 )) # (14400 = 4 hours)
 
+# Number of seconds to wait before timing out each Install or Defer prompt.
+# This value should be less than the $EACH_DEFER value.
+PROMPT_TIMEOUT=$(( 60 * 60 )) # (3600 = 1 hour)
+
 # The number of seconds to wait between displaying the "install updates" message
 # and applying updates, then attempting a soft restart.
 UPDATE_DELAY=$(( 60 * 10 )) # (600 = 10 minutes)
@@ -643,7 +647,7 @@ if (( DEFER_TIME_LEFT > 0 )); then
 
     # Show the install/defer prompt.
     echo "Prompting to install updates now or defer..."
-    PROMPT=$("$JAMFHELPER" -windowType "utility" -windowPosition "ur" -icon "$LOGO" -title "$MSG_INSTALL_OR_DEFER_HEADING" -description "$MSG_INSTALL_OR_DEFER" -button1 "$INSTALL_BUTTON" -button2 "$DEFER_BUTTON" -defaultButton 2 -timeout 3600 -startlaunchd 2>"/dev/null")
+    PROMPT=$("$JAMFHELPER" -windowType "utility" -windowPosition "ur" -icon "$LOGO" -title "$MSG_INSTALL_OR_DEFER_HEADING" -description "$MSG_INSTALL_OR_DEFER" -button1 "$INSTALL_BUTTON" -button2 "$DEFER_BUTTON" -defaultButton 2 -timeout "$PROMPT_TIMEOUT" -startlaunchd 2>"/dev/null")
     JAMFHELPER_PID="$!"
 
     # Make a note of the amount of time the prompt was shown onscreen.

--- a/payload/Library/Scripts/Install or Defer.sh
+++ b/payload/Library/Scripts/Install or Defer.sh
@@ -29,11 +29,11 @@
 PLIST="/Library/Preferences/com.github.mpanighetti.install-or-defer"
 
 # The identifier of the LaunchDaemon that is used to call this script, which
-# should match the file in the payload/Library/LaunchDaemons folder. Omit
+# should match the file name in the payload/Library/LaunchDaemons folder. Omit
 # ".plist" extension.
 BUNDLE_ID="com.github.mpanighetti.install-or-defer"
 
-# The file path of this script.
+# The file path of this script. Used to assist with resource file clean-up.
 SCRIPT_PATH="/Library/Scripts/Install or Defer.sh"
 
 

--- a/payload/Library/Scripts/Install or Defer.sh
+++ b/payload/Library/Scripts/Install or Defer.sh
@@ -88,8 +88,8 @@ MSG_UPDATING="Installing updates for %UPDATE_LIST% in the background.<< Your Mac
 # When the user clicks "Defer" the next prompt is delayed by this much time.
 EACH_DEFER=$(( 60 * 60 * 4 )) # (14400 = 4 hours)
 
-# Number of seconds to wait before timing out each Install or Defer prompt.
-# This value should be less than the $EACH_DEFER value.
+# The number of seconds to wait before timing out each Install or Defer prompt.
+# This value should be less than the EACH_DEFER value.
 PROMPT_TIMEOUT=$(( 60 * 60 )) # (3600 = 1 hour)
 
 # The number of seconds to wait between displaying the "install updates" message

--- a/scripts/postinstall
+++ b/scripts/postinstall
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-MAIN_LD="$3/Library/LaunchDaemons/com.github.mpanighetti.install-or-defer.plist"
+MAIN_LD="${3}/Library/LaunchDaemons/com.github.mpanighetti.install-or-defer.plist"
 
 # Set ownership and permissions on LaunchDaemon (in case files were modified
 # prior to distribution and ownership/permissions were not properly set).

--- a/scripts/preinstall
+++ b/scripts/preinstall
@@ -12,11 +12,11 @@ remove_resource () {
             # remove the launchd task before file deletion.
             if /bin/launchctl list | /usr/bin/grep -q "$PLIST_LABEL"; then
                 /bin/launchctl remove "$PLIST_LABEL"
-                echo "Removed LaunchDaemon: $PLIST_LABEL"
+                echo "Removed LaunchDaemon: ${PLIST_LABEL}"
             fi
         fi
         /bin/rm -rf "$1"
-        echo "Deleted file: $1"
+        echo "Deleted file: ${1}"
     fi
 }
 
@@ -29,8 +29,8 @@ echo "Killing any active jamfHelper notifications..."
 
 # Remove all script resources (if present).
 echo "Removing existing script resources..."
-remove_resource "$3/Library/LaunchDaemons/com.github.mpanighetti.install-or-defer.plist"
-remove_resource "$3/Library/Preferences/com.github.mpanighetti.install-or-defer.plist"
-remove_resource "$3/Library/Scripts/Install or Defer.sh"
-remove_resource "$3/Library/Scripts/Install or Defer_helper.sh"
-remove_resource "$3/private/tmp/install-or-defer"
+remove_resource "${3}/Library/LaunchDaemons/com.github.mpanighetti.install-or-defer.plist"
+remove_resource "${3}/Library/Preferences/com.github.mpanighetti.install-or-defer.plist"
+remove_resource "${3}/Library/Scripts/Install or Defer.sh"
+remove_resource "${3}/Library/Scripts/Install or Defer_helper.sh"
+remove_resource "${3}/private/tmp/install-or-defer"


### PR DESCRIPTION
- consolidated all configuration profile key retrieval actions into a new section and removed legacy manual entry fields for those settings
  - assigned configuration profile keys for button labels (`InstallButtonLabel` and `DeferButtonLabel`), messaging logo (`MessagingLogo`), and workday start/end hours (`WorkdayStartHour` and `WorkdayEndHour`)
  - added `SupportContact` configuration profile key (inputs contact information for technical support team in alert messaging)
    - added `%SUPPORT_CONTACT%` placeholder to all messaging to substitute in with above profile key (defaults to "IT" if undefined)
  - added `DiagnosticLog` configuration profile key (writes output to a diagnostic log at `/var/log/install-or-defer.log` instead of outputting to system log) #63
- added `PROMPT_TIMEOUT` timing variable to customize how long the Install or Defer message persists onscreen (default 1 hour)
- removed `com.apple.softwareupdated` kickstart action from Apple Silicon prompt loop (was displaying errors in Software Update interface)
- added macOS Monterey support #72
- removed macOS High Sierra support