### PR TITLE
#54 Found no recommended update fix

### DIFF
--- a/payload/Library/Scripts/Install or Defer.sh
+++ b/payload/Library/Scripts/Install or Defer.sh
@@ -279,6 +279,9 @@ check_for_updates () {
     MSG_INSTALL="$(echo "$MSG_INSTALL" | /usr/bin/sed "s/%UPDATE_LIST%/${UPDATE_LIST}/")"
     MSG_INSTALL_NOW="$(echo "$MSG_INSTALL_NOW" | /usr/bin/sed "s/%UPDATE_LIST%/${UPDATE_LIST}/")"
     MSG_UPDATING="$(echo "$MSG_UPDATING" | /usr/bin/sed "s/%UPDATE_LIST%/${UPDATE_LIST}/")"
+    
+    # Add variables to PLIST so they can be accessed when the script re-runs
+    /usr/bin/defaults write "$PLIST" UPDATE_LIST -string "$UPDATE_LIST"
 
 }
 
@@ -628,6 +631,8 @@ if [[ -z "$FORCE_DATE" || "$FORCE_DATE" -gt $(( $(/bin/date +%s) + MAX_DEFERRAL_
     check_for_updates
     FORCE_DATE=$(( $(/bin/date +%s) + MAX_DEFERRAL_TIME ))
     /usr/bin/defaults write "$PLIST" UpdatesForcedAfter -int "$FORCE_DATE"
+else 
+    UPDATE_LIST=$(/usr/bin/defaults read "$PLIST" UPDATE_LIST 2>"/dev/null")
 fi
 
 # If a workday start and end hour have been defined and the deadline currently

--- a/payload/Library/Scripts/Install or Defer.sh
+++ b/payload/Library/Scripts/Install or Defer.sh
@@ -632,6 +632,7 @@ if [[ -z "$FORCE_DATE" || "$FORCE_DATE" -gt $(( $(/bin/date +%s) + MAX_DEFERRAL_
     FORCE_DATE=$(( $(/bin/date +%s) + MAX_DEFERRAL_TIME ))
     /usr/bin/defaults write "$PLIST" UpdatesForcedAfter -int "$FORCE_DATE"
 else 
+    # Read in the update_list from the preferences file
     UPDATE_LIST=$(/usr/bin/defaults read "$PLIST" UPDATE_LIST 2>"/dev/null")
 fi
 

--- a/payload/Library/Scripts/Install or Defer.sh
+++ b/payload/Library/Scripts/Install or Defer.sh
@@ -621,12 +621,11 @@ MSG_INSTALL="$(echo "$MSG_INSTALL" | /usr/bin/sed "s/%SUPPORT_CONTACT%/${SUPPORT
 MSG_INSTALL_NOW="$(echo "$MSG_INSTALL_NOW" | /usr/bin/sed "s/%SUPPORT_CONTACT%/${SUPPORT_CONTACT}/")"
 MSG_UPDATING="$(echo "$MSG_UPDATING" | /usr/bin/sed "s/%SUPPORT_CONTACT%/${SUPPORT_CONTACT}/")"
 
-# Check for updates, exit if none found, otherwise continue.
-check_for_updates
-
 # Perform first-run tasks, including calculating deadline.
 FORCE_DATE=$(/usr/bin/defaults read "$PLIST" UpdatesForcedAfter 2>"/dev/null")
 if [[ -z "$FORCE_DATE" || "$FORCE_DATE" -gt $(( $(/bin/date +%s) + MAX_DEFERRAL_TIME )) ]]; then
+    # Check for updates, exit if none found, otherwise continue.
+    check_for_updates
     FORCE_DATE=$(( $(/bin/date +%s) + MAX_DEFERRAL_TIME ))
     /usr/bin/defaults write "$PLIST" UpdatesForcedAfter -int "$FORCE_DATE"
 fi


### PR DESCRIPTION
This forces install or defer to call softwareupdate --list on the initial install of the PKG, subsequent execution of the script via the LaunchDaemon runtime length will bypass softwareupdate --list and use the existing information when prompting the user to defer or install.

#54 