### PR TITLE
moved all timing variables to configuration profile keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,18 +69,38 @@ This framework is designed to work "out of the box" without any modification, bu
 
 You can customize many settings using a configuration profile targeting the `$BUNDLE_ID` preference domain. This allows you to apply different configurations to different groups of Macs (e.g. a dedicated test group could have shorter deferral times), and lets you make changes to these settings on the fly without repackaging and redeploying the script. The following settings can be defined via configuration profile keys:
 
+
+#### Keys
+
+##### Alerting
+
 | Key                      | Type             | Default Value |Minimum Version | Description |
 |--------------------------|------------------|---------------|----------------|-------------|
 |`InstallButtonLabel`      |string|Install|[5.0](https://github.com/mpanighetti/install-or-defer/releases/tag/v5.0)|The label of the install button. Keep this string short since `jamfHelper` will cut off longer button labels.|
 |`DeferButtonLabel`        |string|Defer|[5.0](https://github.com/mpanighetti/install-or-defer/releases/tag/v5.0)|The label of the defer button. Keep this string short since `jamfHelper` will cut off longer button labels.|
-|`DiagnosticLog`           |boolean|`false`|[5.0](https://github.com/mpanighetti/install-or-defer/releases/tag/v5.0)|Whether to write to a persistent log file at `/var/log/install-or-defer.log`. If undefined or set to false, the script writes all output to the system log for live diagnostics.|
-|`ManualUpdates`           |boolean|Apple Silicon: `true`<br />Intel: `false`|[5.0.3](https://github.com/mpanighetti/install-or-defer/releases/tag/v5.0.3)|Whether to prompt users to run updates manually via System Preferences. This is always the behavior on Apple Silicon Macs and cannot be overridden. If undefined or set to false on Intel Macs, the script triggers updates via scripted `softwareupdate` commands.|
-|`MaxDeferralTime`         |integer|`259200`|[2.2](https://github.com/mpanighetti/install-or-defer/releases/tag/v2.2)|Number of seconds between the first script run and the updates being enforced. Defaults to 259200 (3 days).|
+|`DisablePostInstallAlert` |boolean|`false`|[5.0.4](https://github.com/mpanighetti/install-or-defer/releases/tag/v5.0.4)|Whether to suppress the persistent alert to run updates. If set to True, clicking the install button will only launch the Software Update pane without displaying a persistent alert to upgrade, until the deadline date is reached.|
 |`MessagingLogo`           |string|Software Update icon|[5.0](https://github.com/mpanighetti/install-or-defer/releases/tag/v5.0)|File path to a logo that will be used in messaging. Recommend 512px, PNG format.|
-|`SkipDeferral`            |boolean|`false`|[2.2](https://github.com/mpanighetti/install-or-defer/releases/tag/v2.2)|Whether to bypass deferral time entirely and skip straight to update enforcement (useful for script testing purposes). If set to true, this setting supersedes any values set for `MaxDeferralTime`.|
 |`SupportContact`          |string|IT|[5.0](https://github.com/mpanighetti/install-or-defer/releases/tag/v5.0)|Contact information for technical support included in messaging alerts. Recommend using a team name (e.g. "Technical Support"), email address (e.g. "support@contoso.com"), or chat channel (e.g. "#technical-support").|
+
+##### Timing
+
+| Key                      | Type             | Default Value |Minimum Version | Description |
+|--------------------------|------------------|---------------|----------------|-------------|
+|`DeferralPeriod`          |integer|`14400`|[5.0.5](https://github.com/mpanighetti/install-or-defer/releases/tag/v5.0.5)|Number of seconds between when the user clicks "Defer" and the next prompt appears. This value must be less than the `MaxDeferralTime` value.|
+|`HardRestartDelay`        |integer|`300`|[5.0.5](https://github.com/mpanighetti/install-or-defer/releases/tag/v5.0.5)|Number of seconds to wait between attempting a soft restart and forcing a restart.|
+|`MaxDeferralTime`         |integer|`259200`|[2.2](https://github.com/mpanighetti/install-or-defer/releases/tag/v2.2)|Number of seconds between the first script run and the updates being enforced. Defaults to 259200 (3 days).|
+|`PromptTimeout`           |integer|`3600`|[5.0.5](https://github.com/mpanighetti/install-or-defer/releases/tag/v5.0.5)|Number of seconds to wait before timing out the Install or Defer prompt. This value must be less than the `DeferralPeriod` value.|
+|`SkipDeferral`            |boolean|`false`|[2.2](https://github.com/mpanighetti/install-or-defer/releases/tag/v2.2)|Whether to bypass deferral time entirely and skip straight to update enforcement (useful for script testing purposes). If set to true, this setting supersedes any values set for `MaxDeferralTime`.|
+|`UpdateDelay`             |integer|`600`|[5.0.5](https://github.com/mpanighetti/install-or-defer/releases/tag/v5.0.5)|Number of seconds to wait between displaying the "install updates" message and applying updates, then attempting a soft restart.|
 |`WorkdayStartHour`        |integer||[5.0](https://github.com/mpanighetti/install-or-defer/releases/tag/v5.0)|The hour that a workday starts in your organization. This value must be an integer between 0 and 22, and the end hour must be later than the start hour. If the update deadline falls within this window of time, it will be moved forward to occur at the end of the workday. If `WorkdayStartHour` or `WorkdayEndHour` are undefined, deadlines will be scheduled based on maximum deferral time and not account for the time of day that the deadline lands.|
 |`WorkdayEndHour`          |integer||[5.0](https://github.com/mpanighetti/install-or-defer/releases/tag/v5.0)|The hour that a workday ends in your organization. This value must be an integer between 1 and 23, and the end hour must be later than the start hour. If the update deadline falls within this window of time, it will be moved forward to occur at the end of the workday. If `WorkdayStartHour` or `WorkdayEndHour` are undefined, deadlines will be scheduled based on maximum deferral time and not account for the time of day that the deadline lands.|
+
+##### Backend
+
+| Key                      | Type             | Default Value |Minimum Version | Description |
+|--------------------------|------------------|---------------|----------------|-------------|
+|`DiagnosticLog`           |boolean|`false`|[5.0](https://github.com/mpanighetti/install-or-defer/releases/tag/v5.0)|Whether to write to a persistent log file at `/var/log/install-or-defer.log`. If undefined or set to false, the script writes all output to the system log for live diagnostics.|
+|`ManualUpdates`           |boolean|Apple Silicon: `true`<br />Intel: `false`|[5.0.3](https://github.com/mpanighetti/install-or-defer/releases/tag/v5.0.3)|Whether to prompt users to run updates manually via System Preferences. This is always the behavior on Apple Silicon Macs and cannot be overridden. If undefined or set to false on Intel Macs, the script triggers updates via scripted `softwareupdate` commands.|
 
 #### Create a configuration profile in Jamf Pro
 
@@ -158,25 +178,6 @@ The above messages use the following dynamic substitutions:
 - `%UPDATE_LIST%` will be automatically replaced with a comma-separated list of all recommended updates found in a Software Update check.
 - The section in the `{{double curly brackets}}` will be removed when this message is displayed for the final time before the deferral deadline.
 - The sections in the `<<double comparison operators>>` will be removed if a restart is not required for the pending updates.
-
-#### Timing
-
-- `EACH_DEFER`
-
-    When the user clicks "Defer" the next prompt is delayed by this much time.
-
-- `PROMPT_TIMEOUT`
-
-    The number of seconds to wait before timing out each Install or Defer prompt. This value should be less than the `EACH_DEFER` value.
-
-- `UPDATE_DELAY`
-
-    The number of seconds to wait between displaying the "run updates" message and applying updates, then attempting a soft restart.
-
-- `HARD_RESTART_DELAY`
-
-    The number of seconds to wait between attempting a soft restart and forcing a restart.
-
 
 ### Installer creation
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This framework will enforce the installation of pending Apple security updates o
 
 This workflow is most useful for updates that require a restart and include important security-related patches (e.g. macOS Catalina 10.15.7 Supplemental), but also applies to security updates that don't require a restart (e.g. Safari 14.0.3). Basically, anything Software Update marks as "recommended" or requiring a restart is in scope.
 
-This framework is distributed in the form of a [munkipkg](https://github.com/munki/munki-pkg) project, which allows easy creation of a new installer package when changes are made to the script or to the LaunchDaemon that runs it (despite the name, packages generated with munkipkg don't require Munki; they work great with Jamf Pro). See the [Installer creation](#installer-creation) section below for specific steps on creating the installer for this framework.
+This framework is distributed in the form of a [munkipkg](https://github.com/munki/munki-pkg) project, which allows easy creation of a new installer package when changes are made to the script or to the LaunchDaemon that runs it. See the [Installer creation](#installer-creation) section below for specific steps on creating the installer for this framework.
 
 
 ## Requirements
@@ -180,20 +180,24 @@ The above messages use the following dynamic substitutions:
 
 ### Installer creation
 
-Download and install [munkipkg](https://github.com/munki/munki-pkg), if you haven't already. Add the `munkipkg` binary location to your `PATH` or create an alias in your bash profile so that you can reference the command directly.
+1. Install the packaging prerequisites:
 
-If you make changes to the script, we recommend changing the following three things:
+    - Python (does not ship with latest macOS; easiest way to get it is by installing Xcode Command Line Tools: `xcode-select --install`)
+    - [munkipkg](https://github.com/munki/munki-pkg)
 
-- The __Last Modified__ metadata in the script.
-- The __Version__ metadata in the script.
-- The `version` key in the build-info.plist file (to match the script version).
+2. Make all desired modifications to the framework. If you make changes to the script, we recommend changing the following three things:
 
-With munkipkg installed, this command will generate a new installer package in the build folder:
+    - The __Last Modified__ metadata in the script.
+    - The __Version__ metadata in the script.
+    - The `version` key in the build-info.plist file (to match the script version).
 
-    munkipkg /path/to/install-or-defer
+3. With `munkipkg` installed and with `python` in your `$PATH` definitions, this command will generate a new installer package in the build folder (replace paths with the full path to munkipkg and install-or-defer respectively):
 
-The subsequent installer package can be uploaded to Jamf Pro and scoped as specified below in the Jamf Pro setup section.
+    python /path/to/munkipkg /path/to/install-or-defer
 
+4. The subsequent installer package can be uploaded to Jamf Pro and scoped as specified below in the Jamf Pro setup section.
+
+[See the munkipkg README for more information on how to use the tool.](https://github.com/munki/munki-pkg#basic-operation)
 
 ## Jamf Pro setup
 

--- a/build-info.plist
+++ b/build-info.plist
@@ -17,6 +17,6 @@
 	<key>suppress_bundle_relocation</key>
 	<true/>
 	<key>version</key>
-	<string>5.0.3</string>
+	<string>5.0.5</string>
 </dict>
 </plist>

--- a/payload/Library/Scripts/Install or Defer.sh
+++ b/payload/Library/Scripts/Install or Defer.sh
@@ -15,7 +15,7 @@
 #                   https://github.com/mpanighetti/install-or-defer
 #         Authors:  Mario Panighetti and Elliot Jordan
 #         Created:  2017-03-09
-#   Last Modified:  2022-06-08
+#   Last Modified:  2022-06-09
 #         Version:  5.0.5
 #
 ###
@@ -645,7 +645,7 @@ if [ -n "$MANUAL_UPDATES_CUSTOM" ]; then
         MANUAL_UPDATES="False"
     fi
 fi
-echo "Maximum deferral time: $(convert_seconds "$MAX_DEFERRAL_TIME")"
+echo "Manual updates: ${MANUAL_UPDATES}"
 
 # Check for a custom messaging logo image, otherwise default to the Software
 # Update preference pane icon.

--- a/payload/Library/Scripts/Install or Defer.sh
+++ b/payload/Library/Scripts/Install or Defer.sh
@@ -350,10 +350,9 @@ display_act_msg () {
 # defined by previous checks).
 install_updates () {
 
-    # For Apple Silicon Macs, or if specified in a configuration profile
-    # setting, inform the user of required updates and open the Software Update
-    # window to have the user manually run updates.
-    if [[ "$PLATFORM_ARCH" = "arm64" ]] || [[ "$MANUAL_UPDATES" = "True" ]]; then
+    # If manual updates are enabled, inform the user of required updates and
+    # open the Software Update window.
+    if [[ "$MANUAL_UPDATES" = "True" ]]; then
 
         # If persistent notification is disabled and there is still deferral
         # time left, just open Software Update once.
@@ -636,7 +635,9 @@ echo "Defer button label: ${DEFER_BUTTON}"
 
 # Whether to have the user run updates manually (default to false on Intel Macs,
 # always true on Apple Silicon Macs.)
-if [[ -n "$MANUAL_UPDATES_CUSTOM" ]]; then
+if [[ "$PLATFORM_ARCH" = "arm64" ]]; then
+    MANUAL_UPDATES="True"
+elif [[ -n "$MANUAL_UPDATES_CUSTOM" ]]; then
     if [[ "$MANUAL_UPDATES_CUSTOM" -eq 1 ]]; then
         MANUAL_UPDATES="True"
     elif [[ "$MANUAL_UPDATES_CUSTOM" -eq 0 ]]; then

--- a/payload/Library/Scripts/Install or Defer.sh
+++ b/payload/Library/Scripts/Install or Defer.sh
@@ -346,18 +346,20 @@ display_act_msg () {
 
 }
 
-# Displays HUD with updating message and installs all security updates (as
-# defined by previous checks).
+# Opens System Preferences -> Software Update, optionally prompting user to
+# install updates via HUD message and automatically applying the update when
+# able.
 install_updates () {
 
     # If manual updates are enabled, inform the user of required updates and
     # open the Software Update window.
     if [[ "$MANUAL_UPDATES" = "True" ]]; then
 
+        echo "Script has been configured to have user run updates manually."
         # If persistent notification is disabled and there is still deferral
         # time left, just open Software Update once.
         if [[ "$DISABLE_POST_INSTALL_ALERT_CUSTOM" -eq 1 ]] && (( DEFER_TIME_LEFT > 0 )) ; then
-        echo "Manual updates enabled, but persistent alerting is disabled. Opening Software Update..."
+        echo "Persistent alerting is disabled with deferral time remaining. Opening Software Update a single time..."
 
         # Open System Preferences -> Software Update in current user context.
         /bin/launchctl asuser "$USER_ID" open "/System/Library/PreferencePanes/SoftwareUpdate.prefPane"
@@ -365,7 +367,7 @@ install_updates () {
         # Display a persistent alert while opening Software Update and repeat
         # until the user manually runs updates.
         else
-            echo "Manual updates enabled. Displaying persistent alert until updates are applied..."
+            echo "Displaying persistent alert until updates are applied..."
 
             # Loop this check until softwareupdate --list shows no more pending
             # recommended updates.

--- a/payload/Library/Scripts/Install or Defer.sh
+++ b/payload/Library/Scripts/Install or Defer.sh
@@ -175,6 +175,7 @@ MANUAL_UPDATES_CUSTOM=$(/usr/bin/defaults read "/Library/Managed Preferences/${B
 
 echo "Calculating script timing..."
 
+# Set maximum deferral to 0 if deferral skip is enabled.
 if [[ "$SKIP_DEFERRAL_CUSTOM" -eq 1 ]]; then
     MAX_DEFERRAL_TIME=0
 else
@@ -250,7 +251,7 @@ restart_softwareupdate_daemon () {
         /usr/bin/defaults delete "/Library/Preferences/com.apple.SoftwareUpdate.plist"
         /bin/rm -f "/Library/Preferences/com.apple.SoftwareUpdate.plist"
         # Write macOS beta channel catalog URL back to the plist if previously defined.
-        if [ -n "$SOFTWAREUPDATE_CATALOG_URL" ]; then
+        if [[ -n "$SOFTWAREUPDATE_CATALOG_URL" ]]; then
             /usr/bin/defaults write "/Library/Preferences/com.apple.SoftwareUpdate" CatalogURL -string "$SOFTWAREUPDATE_CATALOG_URL"
             echo "Restored macOS beta channel catalog URL."
         fi
@@ -352,11 +353,11 @@ install_updates () {
     # For Apple Silicon Macs, or if specified in a configuration profile
     # setting, inform the user of required updates and open the Software Update
     # window to have the user manually run updates.
-    if [[ "$PLATFORM_ARCH" = "arm64" ]] || [ "$MANUAL_UPDATES" = "True" ]; then
+    if [[ "$PLATFORM_ARCH" = "arm64" ]] || [[ "$MANUAL_UPDATES" = "True" ]]; then
 
         # If persistent notification is disabled and there is still deferral
         # time left, just open Software Update once.
-        if [ "$DISABLE_POST_INSTALL_ALERT_CUSTOM" -eq 1 ] && (( DEFER_TIME_LEFT > 0 )) ; then
+        if [[ "$DISABLE_POST_INSTALL_ALERT_CUSTOM" -eq 1 ]] && (( DEFER_TIME_LEFT > 0 )) ; then
         echo "Manual updates enabled, but persistent alerting is disabled. Opening Software Update..."
 
         # Open System Preferences -> Software Update in current user context.
@@ -560,7 +561,7 @@ PLATFORM_ARCH="$(/usr/bin/arch)"
 # /Library/Preferences/com.apple.SoftwareUpdate.plist if that file is reset in
 # the restart_softwareupdate_daemon function.
 SOFTWAREUPDATE_CATALOG_URL=$(/usr/bin/defaults read "/Library/Preferences/com.apple.SoftwareUpdate" CatalogURL 2>"/dev/null")
-if [ -n "$SOFTWAREUPDATE_CATALOG_URL" ]; then
+if [[ -n "$SOFTWAREUPDATE_CATALOG_URL" ]]; then
     echo "Found macOS beta channel catalog URL, will retain this setting whenever com.apple.SoftwareUpdate is reset: ${SOFTWAREUPDATE_CATALOG_URL}"
 fi
 
@@ -618,14 +619,14 @@ fi
 
 # Validate configuration profile-enforced settings or use script defaults accordingly.
 # Whether to use custom labels for the install/defer buttons (default to "Install" and "Defer").
-if [ -n "$INSTALL_BUTTON_CUSTOM" ]; then
+if [[ -n "$INSTALL_BUTTON_CUSTOM" ]]; then
     INSTALL_BUTTON="$INSTALL_BUTTON_CUSTOM"
 else
     echo "Install button label undefined by administrator. Using default value."
     INSTALL_BUTTON="Install"
 fi
 echo "Install button label: ${INSTALL_BUTTON}"
-if [ -n "$DEFER_BUTTON_CUSTOM" ]; then
+if [[ -n "$DEFER_BUTTON_CUSTOM" ]]; then
     DEFER_BUTTON="$DEFER_BUTTON_CUSTOM"
 else
     echo "Defer button label undefined by administrator. Using default value."
@@ -635,15 +636,18 @@ echo "Defer button label: ${DEFER_BUTTON}"
 
 # Whether to have the user run updates manually (default to false on Intel Macs,
 # always true on Apple Silicon Macs.)
-if [ -n "$MANUAL_UPDATES_CUSTOM" ]; then
-    if [ "$MANUAL_UPDATES_CUSTOM" -eq 1 ]; then
+if [[ -n "$MANUAL_UPDATES_CUSTOM" ]]; then
+    if [[ "$MANUAL_UPDATES_CUSTOM" -eq 1 ]]; then
         MANUAL_UPDATES="True"
-    elif [ "$MANUAL_UPDATES_CUSTOM" -eq 0 ]; then
+    elif [[ "$MANUAL_UPDATES_CUSTOM" -eq 0 ]]; then
         MANUAL_UPDATES="False"
     else
-        echo "Manual update preference undefined by administrator, or not set to a valid boolean. Using default value."
+        echo "Manual update preference not set to a valid boolean. Using default value."
         MANUAL_UPDATES="False"
     fi
+else
+    echo "Manual update preference undefined by administrator. Using default value."
+    MANUAL_UPDATES="False"
 fi
 echo "Manual updates: ${MANUAL_UPDATES}"
 
@@ -658,7 +662,7 @@ fi
 echo "Messaging logo: ${MESSAGING_LOGO}"
 
 # Populate support contact information (default to "IT").
-if [ -n "$SUPPORT_CONTACT_CUSTOM" ]; then
+if [[ -n "$SUPPORT_CONTACT_CUSTOM" ]]; then
     SUPPORT_CONTACT="$SUPPORT_CONTACT_CUSTOM"
 else
     SUPPORT_CONTACT="IT"
@@ -681,7 +685,7 @@ fi
 
 # If a workday start and end hour have been defined and the deadline currently
 # occurs during the workday, shift it forward to the end of the workday.
-if [ -n "$WORKDAY_START_HR_CUSTOM" ] && [ -n "$WORKDAY_END_HR_CUSTOM" ]; then
+if [[ -n "$WORKDAY_START_HR_CUSTOM" ]] && [[ -n "$WORKDAY_END_HR_CUSTOM" ]]; then
     FORCE_DATE_HR=$(/bin/date -jf "%s" "+%H" "$FORCE_DATE")
     if [[ "$FORCE_DATE_HR" -ge "$WORKDAY_START_HR_CUSTOM" ]] && [[ "$FORCE_DATE_HR" -lt "$WORKDAY_END_HR_CUSTOM" ]]; then
         FORCE_DATE_YMD=$(/bin/date -jf "%s" "+%Y-%m-%d" "$FORCE_DATE")

--- a/payload/Library/Scripts/Install or Defer.sh
+++ b/payload/Library/Scripts/Install or Defer.sh
@@ -367,7 +367,6 @@ install_updates () {
         else
             echo "Manual updates enabled. Displaying persistent alert until updates are applied..."
 
-
             # Loop this check until softwareupdate --list shows no more pending
             # recommended updates.
             while [[ $(/usr/sbin/softwareupdate --list) == *"Recommended: YES"* ]]; do


### PR DESCRIPTION
- moved all timing variables to configuration profile keys:
  - `DeferralPeriod`: number of seconds between deferral prompts
  - `HardRestartDelay`: number of seconds between soft and hard restart attempts
  - `PromptTimeout`: number of seconds before script prompts time out
  - `UpdateDelay`: number of seconds between final alert and soft restart attempt
- regrouped all configuration profile keys in script reference and README by category
- added munkipkg run steps and prerequisites
- added link to munkipkg README for more information