### PR TITLE
excluded MDM-deferred updates from enforcement

### DIFF
--- a/build-info.plist
+++ b/build-info.plist
@@ -17,6 +17,6 @@
 	<key>suppress_bundle_relocation</key>
 	<true/>
 	<key>version</key>
-	<string>5.0.7</string>
+	<string>5.0.8</string>
 </dict>
 </plist>

--- a/payload/Library/Scripts/Install or Defer.sh
+++ b/payload/Library/Scripts/Install or Defer.sh
@@ -222,8 +222,16 @@ check_for_updates () {
 
     restart_softwareupdate_daemon "30"
     echo "Checking for pending system updates..."
-    # Capture output of softwareupdate --list, omitting any lines containing updates deferred via MDM.
+    # Capture output of softwareupdate --list, omitting any lines containing
+    # updates deferred via MDM.
     UPDATE_CHECK="$(/usr/sbin/softwareupdate --list 2>&1 | /usr/bin/grep -v 'Deferred: YES')"
+    # For Macs running macOS Monterey, remove any lines containing "macOS
+    # Ventura". This works around an issue where Monterey's softwareupdate
+    # output includes minor updates for later major macOS releases deferred
+    # via MDM and does not identify them as deferred.
+    if [ "$OS_MAJOR" -eq 12 ]; then
+        UPDATE_CHECK=$(echo "$UPDATE_CHECK" | /usr/bin/grep -v "macOS Ventura")
+    fi
 
     # Determine whether any recommended macOS updates are available.
     # If a restart is required for any pending updates, then install all

--- a/payload/Library/Scripts/Install or Defer.sh
+++ b/payload/Library/Scripts/Install or Defer.sh
@@ -15,8 +15,8 @@
 #                   https://github.com/mpanighetti/install-or-defer
 #         Authors:  Mario Panighetti and Elliot Jordan
 #         Created:  2017-03-09
-#   Last Modified:  2022-09-14
-#         Version:  5.0.7
+#   Last Modified:  2022-12-15
+#         Version:  5.0.8
 #
 ###
 
@@ -222,7 +222,8 @@ check_for_updates () {
 
     restart_softwareupdate_daemon "30"
     echo "Checking for pending system updates..."
-    UPDATE_CHECK="$(/usr/sbin/softwareupdate --list 2>&1)"
+    # Capture output of softwareupdate --list, omitting any lines containing updates deferred via MDM.
+    UPDATE_CHECK="$(/usr/sbin/softwareupdate --list 2>&1 | /usr/bin/grep -v 'Deferred: YES')"
 
     # Determine whether any recommended macOS updates are available.
     # If a restart is required for any pending updates, then install all


### PR DESCRIPTION
- excluded MDM-deferred updates from enforcement #94
- added macOS Monterey-specific workaround for macOS Ventura updates not properly labeled as deferred