### PR TITLE
added macOS Ventura compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This framework will enforce the installation of pending Apple security updates on Jamf Pro-managed Macs. Users will have the option to __Install__ or __Defer__. After a specified amount of time passes, the Mac will be prompted to install the updates, then restart automatically if any updates require it.
 
-This workflow is most useful for updates that require a restart and include important security-related patches (e.g. macOS Catalina 10.15.7 Supplemental), but also applies to security updates that don't require a restart (e.g. Safari 14.0.3). Basically, anything Software Update marks as "recommended" or requiring a restart is in scope.
+This workflow is most useful for updates that require a restart and include important security-related patches (e.g. macOS 13.1), but also applies to security updates that don't require a restart (e.g. Safari 16.2). Basically, anything Software Update marks as "recommended" or requiring a restart is in scope.
 
 This framework is distributed in the form of a [munkipkg](https://github.com/munki/munki-pkg) project, which allows easy creation of a new installer package when changes are made to the script or to the LaunchDaemon that runs it. See the [Installer creation](#installer-creation) section below for specific steps on creating the installer for this framework.
 
@@ -11,7 +11,7 @@ This framework is distributed in the form of a [munkipkg](https://github.com/mun
 
 Here's what needs to be in place in order to use this framework:
 
-- The current version of this framework officially supports __macOS Mojave, Catalina, Big Sur, and Monterey__, but older script versions should continue to function normally for previous macOS releases (note, however, that those versions of macOS are no longer receiving regular security updates from Apple and thus may not benefit from this framework).
+- The current version of this framework officially supports __macOS Catalina, Big Sur, Monterey, and Ventura__, but older script versions should continue to function normally for previous macOS releases (note, however, that those versions of macOS are no longer receiving regular security updates from Apple and thus may not benefit from this framework).
 - Target Macs must be __enrolled in Jamf Pro__ and have the `jamfHelper` binary installed.
 
 ### Optional
@@ -216,22 +216,21 @@ Upload this package (created with munkipkg above) to the Jamf Pro server via Jam
 
 Create a smart group for each software update or operating system patch you wish to enforce. Here are some examples to serve as guides, using regular expressions to allow for fewer criteria:
 
-- __Critical Update Needed: macOS Catalina 10.15.7__
-    - `Operating System Build` `matches regex` `^19[A-G]`
-- __Critical Update Needed: Security Update 2021-002 Mojave__
-    - `Operating System Build` `matches regex` `^18G\d{1,3}$`
-    - `or` `Operating System Build` `matches regex` `^18G[1-7]\d{3}$`
-    - `or` `Operating System Build` `matches regex` `^18G80[0-1]\d$`
-    - `or` `Operating System Build` `matches regex` `^18G802[0-1]$`
+- __Critical Update Needed: macOS Ventura 13.1__
+    - `Operating System Build` `matches regex` `^22[A-B]`
+- __Critical Update Needed: macOS Monterey 12.6.2__
+    - `Operating System Build` `matches regex` `^21[A-F]`
+    - `or` `Operating System Build` `matches regex` `^21G\d{1,2}$`
+    - `or` `Operating System Build` `matches regex` `^21G[1-2]\d{2}$`
+    - `or` `Operating System Build` `matches regex` `^21G3[0-1]\d$`
 
 For completion's sake, here's an example of an update that won't require a restart but is still tagged as `Recommended: YES` in the `softwareupdate` catalog:
 
-- __Critical Update Needed: Safari 14.0.3__
+- __Critical Update Needed: Safari 16.2__
     - `Application Title` `is` `Safari.app`
     - `and` `(` `Application Version` `matches regex` `^\d\.`
-    - `or` `Application Version` `matches regex` `^1[0-3]\.`
-    - `or` `Application Version` `matches regex` `^14\.0$`
-    - `or` `Application Version` `matches regex` `^14\.0\.[0-2]` `)`
+    - `or` `Application Version` `matches regex` `^1[0-5]\.`
+    - `or` `Application Version` `matches regex` `^16\.[0-1]$` `)`
 
 
 ### Policy

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This framework will enforce the installation of pending Apple security updates on Jamf Pro-managed Macs. Users will have the option to __Install__ or __Defer__. After a specified amount of time passes, the Mac will be prompted to install the updates, then restart automatically if any updates require it.
 
-This workflow is most useful for updates that require a restart and include important security-related patches (e.g. macOS 13.1), but also applies to security updates that don't require a restart (e.g. Safari 16.2). Basically, anything Software Update marks as "recommended" or requiring a restart is in scope.
+This workflow is most useful for updates that require a restart and include important security-related patches (e.g. macOS Ventura 13.1), but also applies to application updates that don't require a restart (e.g. Safari 16.2). Basically, anything Software Update marks as "recommended" or requiring a restart is in scope.
 
 This framework is distributed in the form of a [munkipkg](https://github.com/munki/munki-pkg) project, which allows easy creation of a new installer package when changes are made to the script or to the LaunchDaemon that runs it. See the [Installer creation](#installer-creation) section below for specific steps on creating the installer for this framework.
 
@@ -57,8 +57,8 @@ The framework has a few limitations of note:
 
 - Sequential updates cannot be installed as a group (e.g. Security Update 2022-003 Catalina cannot be installed unless 10.15.7 is already installed). If multiple sequential security updates are available, they are treated as two separate rounds of prompting/deferring. As a result, Macs requiring sequential updates may take more than one deferral and enforcement cycle (default 3 days) to be fully patched.
 - Reasonable attempts have been made to make this workflow enforceable, but there's nothing stopping an administrator of a Mac from unloading the LaunchDaemon or resetting the preference file.
-- On Apple Silicon Macs, running `softwareupdate --download` and `softwareupdate --install` via background script are unsupported. When this framework is run on an Apple Silicon Mac, enforcement takes a "softer" form, instead opening System Preferences -> Software Update and leaving a persistent prompt in place until the updates are applied. Note that this workflow requires the Software Update preference pane to be available to a user with a [secure token and volume ownership](https://support.apple.com/guide/deployment/use-secure-and-bootstrap-tokens-dep24dbdcf9e/), so that they can apply available software updates and restart their Mac.
-- Several versions of macOS Big Sur and macOS Monterey have known software update reliability issues, resulting in inconsistently presenting new updates as available or failing to install updates. Some measures have been taken to improve reliability in the latest releases of this framework, but ultimately a resolution will require a fix from Apple. The hope is that these bugs will be fixed in a future macOS software update; in the meantime, see [#54](https://github.com/mpanighetti/install-or-defer/issues/54) and [#76](https://github.com/mpanighetti/install-or-defer/issues/76) for ongoing discussions, and reach out to Apple Enterprise Support to increase signal on the issue.
+- On Apple Silicon Macs, running `softwareupdate --download` and `softwareupdate --install` via background script are unsupported. When this framework is run on an Apple Silicon Mac, enforcement takes a "softer" form, instead opening Software Update and leaving a persistent prompt in place until the updates are applied. Note that this workflow requires the Software Update preference pane to be available to a user with a [secure token and volume ownership](https://support.apple.com/guide/deployment/use-secure-and-bootstrap-tokens-dep24dbdcf9e/), so that they can apply available software updates and restart their Mac.
+- macOS Big Sur, macOS Monterey, and macOS Ventura have known reliability issues when attempting to update your Mac using the `softwareupdate` binary, resulting in inconsistently presenting new updates as available or failing to install updates. Some measures have been taken to improve reliability in the latest releases of this framework, but ultimately a resolution will require a fix from Apple. The hope is that these bugs will be fixed in a future macOS software update; in the meantime, see [#54](https://github.com/mpanighetti/install-or-defer/issues/54) and [#76](https://github.com/mpanighetti/install-or-defer/issues/76) for ongoing discussions, and reach out to Apple Enterprise Support to increase signal on the issue.
 
 
 ## Settings customization
@@ -78,7 +78,7 @@ You can customize many settings using a configuration profile targeting the `$BU
 |--------------------------|------------------|---------------|----------------|-------------|
 |`InstallButtonLabel`      |string|Install|[5.0](https://github.com/mpanighetti/install-or-defer/releases/tag/v5.0)|The label of the install button. Keep this string short since `jamfHelper` will cut off longer button labels.|
 |`DeferButtonLabel`        |string|Defer|[5.0](https://github.com/mpanighetti/install-or-defer/releases/tag/v5.0)|The label of the defer button. Keep this string short since `jamfHelper` will cut off longer button labels.|
-|`DisablePostInstallAlert` |boolean|`false`|[5.0.4](https://github.com/mpanighetti/install-or-defer/releases/tag/v5.0.4)|Whether to suppress the persistent alert to run updates. If set to True, clicking the install button will only launch the Software Update pane without displaying a persistent alert to upgrade, until the deadline date is reached.|
+|`DisablePostInstallAlert` |boolean|`false`|[5.0.4](https://github.com/mpanighetti/install-or-defer/releases/tag/v5.0.4)|Whether to suppress the persistent alert to run updates. If set to True, clicking the install button will only launch Software Update without displaying a persistent alert to upgrade, until the deadline date is reached.|
 |`MessagingLogo`           |string|Software Update icon|[5.0](https://github.com/mpanighetti/install-or-defer/releases/tag/v5.0)|File path to a logo that will be used in messaging. Recommend 512px, PNG format.|
 |`SupportContact`          |string|IT|[5.0](https://github.com/mpanighetti/install-or-defer/releases/tag/v5.0)|Contact information for technical support included in messaging alerts. Recommend using a team name (e.g. "Technical Support"), email address (e.g. "support@contoso.com"), or chat channel (e.g. "#technical-support").|
 
@@ -100,7 +100,7 @@ You can customize many settings using a configuration profile targeting the `$BU
 | Key                      | Type             | Default Value |Minimum Version | Description |
 |--------------------------|------------------|---------------|----------------|-------------|
 |`DiagnosticLog`           |boolean|`false`|[5.0](https://github.com/mpanighetti/install-or-defer/releases/tag/v5.0)|Whether to write to a persistent log file at `/var/log/install-or-defer.log`. If undefined or set to false, the script writes all output to the system log for live diagnostics.|
-|`ManualUpdates`           |boolean|Apple Silicon: `true`<br />Intel: `false`|[5.0.3](https://github.com/mpanighetti/install-or-defer/releases/tag/v5.0.3)|Whether to prompt users to run updates manually via System Preferences. This is always the behavior on Apple Silicon Macs and cannot be overridden. If undefined or set to false on Intel Macs, the script triggers updates via scripted `softwareupdate` commands.|
+|`ManualUpdates`           |boolean|Apple Silicon: `true`<br />Intel: `false`|[5.0.3](https://github.com/mpanighetti/install-or-defer/releases/tag/v5.0.3)|Whether to prompt users to run updates manually via Software Update. This is always the behavior on Apple Silicon Macs and cannot be overridden. If undefined or set to false on Intel Macs, the script triggers updates via scripted `softwareupdate` commands.|
 
 #### Create a configuration profile in Jamf Pro
 
@@ -216,20 +216,16 @@ Upload this package (created with munkipkg above) to the Jamf Pro server via Jam
 
 Create a smart group for each software update or operating system patch you wish to enforce. Here are some examples to serve as guides, using regular expressions to allow for fewer criteria:
 
+#### macOS update regex
+
 - __Critical Update Needed: macOS Ventura 13.1__
     - `Operating System Build` `matches regex` `^22[A-B]`
-- __Critical Update Needed: macOS Monterey 12.6.2__
-    - `Operating System Build` `matches regex` `^21[A-F]`
-    - `or` `Operating System Build` `matches regex` `^21G\d{1,2}$`
-    - `or` `Operating System Build` `matches regex` `^21G[1-2]\d{2}$`
-    - `or` `Operating System Build` `matches regex` `^21G3[0-1]\d$`
 
-For completion's sake, here's an example of an update that won't require a restart but is still tagged as `Recommended: YES` in the `softwareupdate` catalog:
+#### Application update regex
 
 - __Critical Update Needed: Safari 16.2__
     - `Application Title` `is` `Safari.app`
-    - `and` `(` `Application Version` `matches regex` `^\d\.`
-    - `or` `Application Version` `matches regex` `^1[0-5]\.`
+    - `and` `(` `Application Version` `matches regex` `^(\d|1[0-5])\.`
     - `or` `Application Version` `matches regex` `^16\.[0-1]$` `)`
 
 

--- a/build-info.plist
+++ b/build-info.plist
@@ -17,6 +17,6 @@
 	<key>suppress_bundle_relocation</key>
 	<true/>
 	<key>version</key>
-	<string>5.0.8</string>
+	<string>6.0</string>
 </dict>
 </plist>

--- a/payload/Library/Scripts/Install or Defer.sh
+++ b/payload/Library/Scripts/Install or Defer.sh
@@ -15,7 +15,7 @@
 #                   https://github.com/mpanighetti/install-or-defer
 #         Authors:  Mario Panighetti and Elliot Jordan
 #         Created:  2017-03-09
-#   Last Modified:  2023-01-12
+#   Last Modified:  2023-02-03
 #         Version:  6.0
 #
 ###
@@ -669,12 +669,16 @@ fi
 echo "Manual updates: ${MANUAL_UPDATES}"
 
 # Check for a custom messaging logo image, otherwise default to the Software
-# Update preference pane icon.
+# Update icon.
 if [[ -n "$MESSAGING_LOGO_CUSTOM" ]] && [[ -f "$MESSAGING_LOGO_CUSTOM" ]]; then
     MESSAGING_LOGO="$MESSAGING_LOGO_CUSTOM"
 else
     echo "Messaging logo undefined by admininstrator, or not found at specified path. Using default value."
-    MESSAGING_LOGO="/System/Library/PreferencePanes/SoftwareUpdate.prefPane/Contents/Resources/SoftwareUpdate.icns"
+    if [[ "$OS_MAJOR" -lt 13 ]]; then
+        MESSAGING_LOGO="/System/Library/PreferencePanes/SoftwareUpdate.prefPane/Contents/Resources/SoftwareUpdate.icns"
+    else
+        MESSAGING_LOGO="/System/Library/PrivateFrameworks/SoftwareUpdate.framework/Versions/Current/Resources/SoftwareUpdate.icns"
+    fi
 fi
 echo "Messaging logo: ${MESSAGING_LOGO}"
 

--- a/payload/Library/Scripts/Install or Defer.sh
+++ b/payload/Library/Scripts/Install or Defer.sh
@@ -15,8 +15,8 @@
 #                   https://github.com/mpanighetti/install-or-defer
 #         Authors:  Mario Panighetti and Elliot Jordan
 #         Created:  2017-03-09
-#   Last Modified:  2022-12-15
-#         Version:  5.0.8
+#   Last Modified:  2023-01-12
+#         Version:  6.0
 #
 ###
 
@@ -270,20 +270,15 @@ check_for_updates () {
 # Parse software update list for user-facing messaging.
 format_update_list () {
 
-    # Capture update names and versions.
-    if [[ "$OS_MAJOR" -eq 10 && "$OS_MINOR" -lt 15 ]]; then
-        UPDATE_LIST="$(echo "$UPDATE_CHECK" | /usr/bin/awk -F'[\(\)]' '/recommended/ {print $1 $2}')"
+    # Capture update names and versions.  Omit the Version column if the
+    # update list includes a "macOS" update, as those updates tend to
+    # already include version information in the Title column.
+    # Note that this will omit version strings from any other pending
+    # updates, e.g. Safari.
+    if echo "$UPDATE_CHECK" | /usr/bin/grep -q "macOS"; then
+        UPDATE_LIST="$(echo "$UPDATE_CHECK" | /usr/bin/awk -F'[:,]' '/Title:/ {print $2}')"
     else
-        # Omit the Version column if the update list includes a "macOS" update,
-        # as those updates tend to already include version information in the
-        # Title column.
-        # Note that this will omit version strings from any other pending
-        # updates, e.g. Safari.
-        if echo "$UPDATE_CHECK" | /usr/bin/grep -q "macOS"; then
-            UPDATE_LIST="$(echo "$UPDATE_CHECK" | /usr/bin/awk -F'[:,]' '/Title:/ {print $2}')"
-        else
-            UPDATE_LIST="$(echo "$UPDATE_CHECK" | /usr/bin/awk -F'[:,]' '/Title:/ {print $2 $4}')"
-        fi
+        UPDATE_LIST="$(echo "$UPDATE_CHECK" | /usr/bin/awk -F'[:,]' '/Title:/ {print $2 $4}')"
     fi
     # Convert update list from multiline to comma-separated list.
     UPDATE_LIST="$(echo "$UPDATE_LIST" | /usr/bin/tr '\n' ',' | /usr/bin/sed 's/^ *//; s/,/, /g; s/, $//')"
@@ -570,12 +565,12 @@ PLATFORM_ARCH="$(/usr/bin/arch)"
 OS_MAJOR=$(/usr/bin/sw_vers -productVersion | /usr/bin/awk -F . '{print $1}')
 OS_MINOR=$(/usr/bin/sw_vers -productVersion | /usr/bin/awk -F . '{print $2}')
 
-# This script has currently been tested in macOS 10.14, macOS 10.15, macOS 11,
-# and macOS 12. It will exit with error for any other macOS versions.
+# This script has currently been tested in macOS 10.15, macOS 11, macOS 12,
+# and macOS 13. It will exit with error for any other macOS versions.
 # When new versions of macOS are released, this logic should be updated after
 # the script has been tested successfully.
-if [[ "$OS_MAJOR" -lt 10 ]] || [[ "$OS_MAJOR" -eq 10 && "$OS_MINOR" -lt 14 ]] || [[ "$OS_MAJOR" -gt 12 ]]; then
-    bail_out "❌ ERROR: This script supports macOS 10.14 Mojave, macOS 10.15 Catalina, macOS 11 Big Sur, and macOS 12 Monterey, but this Mac is running macOS ${OS_MAJOR}.${OS_MINOR}, unable to proceed."
+if [[ "$OS_MAJOR" -lt 10 ]] || [[ "$OS_MAJOR" -eq 10 && "$OS_MINOR" -lt 15 ]] || [[ "$OS_MAJOR" -gt 13 ]]; then
+    bail_out "❌ ERROR: This script supports macOS 10.15 Catalina, macOS 11 Big Sur, macOS 12 Monterey, and macOS 13 Ventura, but this Mac is running macOS ${OS_MAJOR}.${OS_MINOR}, unable to proceed."
 fi
 
 # Determine software update custom catalog URL if defined. Used for running beta

--- a/payload/Library/Scripts/Install or Defer.sh
+++ b/payload/Library/Scripts/Install or Defer.sh
@@ -106,8 +106,8 @@ INSTALL_BUTTON_CUSTOM=$(/usr/bin/defaults read "/Library/Managed Preferences/${B
 DEFER_BUTTON_CUSTOM=$(/usr/bin/defaults read "/Library/Managed Preferences/${BUNDLE_ID}" DeferButtonLabel 2>"/dev/null")
 # - DisablePostInstallAlert (Boolean). Whether to suppress the persistent alert
 # to run updates. Defaults to False. If set to True, clicking the install button
-# will only launch Software Update without displaying a persistent
-# alert to upgrade, until the deadline date is reached.
+# will only launch Software Update without displaying a persistent alert to
+# upgrade, until the deadline date is reached.
 DISABLE_POST_INSTALL_ALERT_CUSTOM=$(/usr/bin/defaults read "/Library/Managed Preferences/${BUNDLE_ID}" DisablePostInstallAlert 2>"/dev/null")
 # - MessagingLogo (String). File path to a logo that will be used in messaging.
 # Recommend 512px, PNG format. Defaults to the Software Update icon.


### PR DESCRIPTION
- added macOS Ventura compatibility (resolves #93)
  - removed all references to System Preferences as app name is not consistent across all supported macOS releases
  - added Software Update icon path for macOS Ventura and later
- removed macOS Mojave compatibility
- added `quit_jamfhelper` function (replaces all `killall jamfhelper` runs)
- added `bail_out` check for valid Jamf Pro URL definition
- improved manual update check logic
- improved comment and echo phrasing
- updated README examples and consolidated regex examples